### PR TITLE
Update CI and docs

### DIFF
--- a/.github/workflows/publish_to_pypi_test.yml
+++ b/.github/workflows/publish_to_pypi_test.yml
@@ -1,14 +1,7 @@
 name: Publish to PyPI Test
 
 on:
-  pull_request:
-    branches: 
-      - main
-    paths:
-      - 'pyproject.toml'
-      - 'README.md'
-      - 'LICENSE'
-      - '.gchithub/workflows/publish_to_pypi_test.yml'
+  workflow_dispatch:
 
 jobs:
   testpypi:

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,7 +1,7 @@
 name: Python Test & Coverage (Pixi)
 
 on:
-  pull_request:
+  push:
     branches:
       - main
     paths:

--- a/README.md
+++ b/README.md
@@ -17,19 +17,14 @@ BERA Tools is successor of [Forest Line Mapper](https://github.com/appliedgrg/fl
 
 BERA Tools is built upon open-source Python libraries. Anaconda is used to manage runtime environments.
 
-There are multiple ways to install BERA Tools:
+Ways to install BERA Tools:
 
 - Windows installer
-- QGIS Plugin (To be released)
 - Install with Anaconda.
 
 ### Windows Installer
 
 Windows installer is provided with releases. Check the [latest release](https://github.com/appliedgrg/beratools/releases/latest) for the up-to-date installer.
-
-### QGIS Plugin
-
-BERA Tools is also available as a QGIS plugin (To be released).
 
 ### Install with Anaconda
 

--- a/docs/files/developer/maintainer.md
+++ b/docs/files/developer/maintainer.md
@@ -43,15 +43,17 @@ Here is a summary of the actions defined in all workflow files in `.github/workf
     - Trigger: On push or pull request to `main` affecting `beratools/**`.
     - Runs pytest with coverage and uploads results to Codecov.
 
-- __publish_to_pypi_test.yml__
-    - Summary: Pre-merge PyPI test deployment to validate package publishing on PRs.
-    - Trigger: On pull request to `main`.
-    - Builds the package and publishes to TestPyPI.
-
 - __tox.yml__
     - Summary: Matrix testing via tox for multiple Python versions (3.10–3.13).
     - Trigger: On pull request to `main` affecting `beratools/**`.
     - Executes tox across multiple Python versions (matrix) to run tests for each target interpreter.
+
+### Manual (workflow_dispatch)
+
+- __publish_to_pypi_test.yml__
+    - Summary: Manual TestPyPI deployment to validate package publishing on demand.
+    - Trigger: Manually triggered via `workflow_dispatch`.
+    - Builds the package and publishes to TestPyPI.
 
 ### Version tag push
 
@@ -86,8 +88,10 @@ flowchart LR
     Files -->|beratools/**| Pytest[CI Tests]
     
     CheckType -->|PR to main| PR[PR Validation]
-    PR --> PyPITest[Test PyPI]
     PR --> Tox[Tox Grid Tests]
+
+    CheckType -->|Manual trigger| Manual[Workflow Dispatch]
+    Manual --> PyPITest[Test PyPI]
     
     CheckType -->|Version tag| Release[Release]
     Release --> Anaconda[Conda]
@@ -98,7 +102,8 @@ flowchart LR
     classDef rel fill:#e8f5e9,stroke:#2e7d32
     
     class Mkdocs,Pytest push
-    class PyPITest,Tox pr
+    class PyPITest manual
+    class Tox pr
     class Anaconda,PyPI rel
 ```
 

--- a/docs/files/developer/publishing.md
+++ b/docs/files/developer/publishing.md
@@ -20,6 +20,7 @@ See the following workflows:
 
 - Conda Packaging and Release: [publish_to_anaconda.yml](https://github.com/appliedgrg/beratools/blob/main/.github/workflows/publish_to_anaconda.yml)
 - PyPI Packaging and Release: [publish_to_pypi.yml](https://github.com/appliedgrg/beratools/blob/main/.github/workflows/publish_to_pypi.yml)
+- TestPyPI Packaging (manual): [publish_to_pypi_test.yml](https://github.com/appliedgrg/beratools/blob/main/.github/workflows/publish_to_pypi_test.yml)
 
 See two actions details in [Maintainer Guide](maintainer.md#version-tag-push).
 
@@ -28,3 +29,11 @@ See two actions details in [Maintainer Guide](maintainer.md#version-tag-push).
 [Anaconda BERA Tools](https://anaconda.org/appliedgrg/beratools)
 
 [Pypi BERA Tools](https://pypi.org/project/BERATools)
+
+## TestPyPI (Manual Validation)
+
+For release rehearsals or packaging checks, maintainers can trigger the TestPyPI workflow manually.
+
+1. Go to **Actions** in GitHub and select **Publish to PyPI Test**.
+2. Click **Run workflow** to trigger the `workflow_dispatch` job.
+3. The workflow builds the package and publishes it to TestPyPI.

--- a/docs/files/user/installation.md
+++ b/docs/files/user/installation.md
@@ -20,7 +20,7 @@ conda activate bera
 
 ### Using Pip
 
-BERA Tools is published to Pypi and can be installed by pip. But on Windows, GDAL should be installed first. Please refer to [GDAL for Windows](https://gdal.org/en/stable/download.html#windows) for more information.
+BERA Tools is published to Pypi and can be installed by pip. On Windows, if you use the standalone installer, GDAL/PROJ are bundled. For pip-based installs, GDAL should be installed first. Please refer to [GDAL for Windows](https://gdal.org/en/stable/download.html#windows) for more information.
 
 Example: install GDAL from a Windows wheel (adjust the URL/version as needed):
 


### PR DESCRIPTION
This pull request updates documentation and GitHub workflow configuration to clarify and improve the process for publishing and testing BERA Tools releases, especially regarding manual TestPyPI validation. The most important changes include switching the TestPyPI workflow to manual triggering, updating documentation to reflect this, and improving installation instructions.

**Workflow configuration updates:**

* Changed `.github/workflows/publish_to_pypi_test.yml` to use `workflow_dispatch` for manual triggering instead of automatic runs on pull requests to `main`.
* Updated `.github/workflows/python-tests.yml` to run on `push` events to `main` instead of `pull_request`.

**Documentation improvements:**

* Revised `docs/files/developer/maintainer.md` to describe the manual trigger for TestPyPI publishing, updated the workflow summary, and adjusted the flowchart to show manual dispatch.

**Installation instructions:**

* Clarified in `docs/files/user/installation.md` that the Windows installer bundles GDAL/PROJ, while pip installations require manual GDAL setup.
* Simplified installation section in `README.md` and removed references to the unreleased QGIS plugin.