### PR TITLE
Win installer: Make GDAL URL configurable and update build script

### DIFF
--- a/packaging/README.md
+++ b/packaging/README.md
@@ -9,3 +9,13 @@ recipe.yaml
 build.ps1
 beratools.iss
 main.go
+
+## Build locally
+
+Run the following command to build the Windows installer locally:
+
+```powershell
+.\build.ps1
+```
+
+This will generate the installer in the `dist` directory. `build` folder store all temporary files during the build process.

--- a/packaging/build.ps1
+++ b/packaging/build.ps1
@@ -105,17 +105,27 @@ $pyprojectPath = Join-Path $scriptDir "..\pyproject.toml"
 $pyprojectPath = [System.IO.Path]::GetFullPath($pyprojectPath)
 $pyproject = Get-Content $pyprojectPath -Raw
 
-# Extract GDAL URL from pyproject.toml (windows extra)
-if ($pyproject -match 'gdal\s*@\s*(https://[^\s;]+\.whl)') {
+# Extract GDAL URL (prefer env var, then [tool.beratools] gdal_url, then legacy regex)
+$gdalUrl = $env:BERATOOLS_GDAL_URL
+if (-not $gdalUrl -and $pyproject -match '(?m)^\s*\[tool\.beratools\]\s*$([\s\S]*?)(?=^\s*\[|\z)') {
+    $toolBlock = $Matches[1]
+    if ($toolBlock -match '(?m)^\s*gdal_url\s*=\s*"([^"]+)"\s*$') {
+        $gdalUrl = $Matches[1]
+    }
+}
+if (-not $gdalUrl -and $pyproject -match 'gdal\s*@\s*(https://[^\s;]+\.whl)') {
     $gdalUrl = $Matches[1]
-    Write-Host "Installing GDAL wheel..."
-    & (Join-Path $buildDir "python\python.exe") -m pip install $gdalUrl --quiet
+}
+
+if ($gdalUrl) {
+    Write-Host "Installing GDAL wheel from $gdalUrl..."
+    & (Join-Path $buildDir "python\python.exe") -m pip install $gdalUrl --quiet --no-warn-script-location
     if ($LASTEXITCODE -ne 0) {
         Write-Host "Failed to install GDAL" -ForegroundColor Red
         exit 1
     }
 } else {
-    Write-Host "Failed to extract GDAL URL from pyproject.toml" -ForegroundColor Red
+    Write-Host "Failed to extract GDAL URL from pyproject.toml or BERATOOLS_GDAL_URL" -ForegroundColor Red
     exit 1
 }
 
@@ -127,7 +137,7 @@ if ($pyproject -match '(?s)dependencies\s*=\s*\[(.*?)\]') {
         Where-Object { $_ -notmatch 'gdal' }  # Skip gdal, already installed
     
     Write-Host "Installing dependencies: $($deps -join ', ')"
-    & (Join-Path $buildDir "python\python.exe") -m pip install @deps --quiet
+    & (Join-Path $buildDir "python\python.exe") -m pip install @deps --quiet --no-warn-script-location
     if ($LASTEXITCODE -ne 0) {
         Write-Host "Failed to install dependencies" -ForegroundColor Red
         exit 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,9 @@ beratools = "beratools.gui.main:gui_main"
 [project.urls]
 Homepage = "https://github.com/appliedgrg/beratools"
 
+[tool.beratools]
+gdal_url = "https://github.com/cgohlke/geospatial-wheels/releases/download/v2025.10.25/gdal-3.11.4-cp311-cp311-win_amd64.whl"
+
 [tool.hatch.metadata]
 allow-direct-references = true
 


### PR DESCRIPTION
This pull request improves the build process for the Windows installer by making the GDAL wheel URL configurable. The changes also enhance dependency installation and provide a more robust way to extract the GDAL URL.

**Build process improvements:**

* The `build.ps1` script now determines the GDAL wheel URL by checking the `BERATOOLS_GDAL_URL` environment variable first, then the `[tool.beratools] gdal_url` entry in `pyproject.toml`, and finally falls back to the legacy regex if needed. This makes the build more flexible and easier to configure.
* The script now uses the `--no-warn-script-location` flag when installing dependencies and the GDAL wheel, reducing unnecessary warnings during the build. 

**Configuration and documentation updates:**

* Added a `[tool.beratools]` section to `pyproject.toml` with a `gdal_url` key, making the GDAL wheel URL explicit and configurable.
* Updated `packaging/README.md` to include clear instructions for building the Windows installer locally using `build.ps1`.