### PR TITLE
Add clip_to_chm_footprint option

### DIFF
--- a/beratools/gui/assets/beratools.json
+++ b/beratools/gui/assets/beratools.json
@@ -30,7 +30,7 @@
               "subtype": "raster",
               "default": "",
               "output": false,
-              "optional": false
+              "optional": true
             },
             {
               "variable": "chm_footprint_shrink",
@@ -39,6 +39,17 @@
               "type": "number",
               "subtype": "float",
               "default": 15.0,
+              "output": false,
+              "optional": true
+            },
+            {
+              "variable": "clip_to_chm_footprint",
+              "label": "Clip to CHM footprint",
+              "description": "Clip seed lines to CHM footprint after inward shrink.",
+              "type": "list",
+              "subtype": "bool",
+              "data": [true, false],
+              "default": true,
               "output": false,
               "optional": true
             },

--- a/beratools/tools/check_seed_line.py
+++ b/beratools/tools/check_seed_line.py
@@ -37,6 +37,7 @@ print = log.print
 @dataclass
 class SeedLineQCConfig:
     chm_footprint_shrink: float = 15.0
+    clip_to_chm_footprint: bool = True
     remove_short_lines: bool = False
     minimum_line_length: float = 5.0
     snap_close_endpoints: bool = False
@@ -593,6 +594,7 @@ def check_seed_line(
     in_raster,
     out_line,
     chm_footprint_shrink=15.0,
+    clip_to_chm_footprint=True,
     remove_short_lines=False,
     minimum_line_length=5.0,
     snap_close_endpoints=False,
@@ -610,11 +612,9 @@ def check_seed_line(
 
     del processes, call_mode, log_level
 
-    if not in_raster:
-        raise ValueError("Parameter 'in_raster' is required for Check Seed Lines.")
-
     config = SeedLineQCConfig(
         chm_footprint_shrink=float(chm_footprint_shrink),
+        clip_to_chm_footprint=_to_bool(clip_to_chm_footprint),
         remove_short_lines=_to_bool(remove_short_lines),
         minimum_line_length=float(minimum_line_length),
         snap_close_endpoints=_to_bool(snap_close_endpoints),
@@ -629,8 +629,9 @@ def check_seed_line(
     in_file, in_layer = sp_common.decode_file_layer(in_line)
     out_file, out_layer = sp_common.decode_file_layer(out_line)
 
-    if not sp_common.compare_crs(sp_common.vector_crs(in_file), sp_common.raster_crs(in_raster)):
-        raise ValueError("Input line and raster CRS do not match.")
+    if config.clip_to_chm_footprint and in_raster:
+        if not sp_common.compare_crs(sp_common.vector_crs(in_file), sp_common.raster_crs(in_raster)):
+            raise ValueError("Input line and raster CRS do not match.")
 
     gdf = gpd.read_file(in_file, layer=in_layer)
     logger.info("Seed line QC start: %s feature(s)", len(gdf))
@@ -664,11 +665,20 @@ def check_seed_line(
 
     step_name = "CHM footprint clipping"
     in_count = len(gdf)
-    t0 = _step_timer()
-    gdf = _clip_to_chm_footprint(gdf, in_raster, config.chm_footprint_shrink)
-    _log_step(4, step_name, in_count, len(gdf), _elapsed(t0))
-    if _bail_if_empty(gdf, step_name, out_file, out_layer, in_count):
-        return
+    if config.clip_to_chm_footprint:
+        if in_raster:
+            t0 = _step_timer()
+            gdf = _clip_to_chm_footprint(gdf, in_raster, config.chm_footprint_shrink)
+            _log_step(4, step_name, in_count, len(gdf), _elapsed(t0))
+            if _bail_if_empty(gdf, step_name, out_file, out_layer, in_count):
+                return
+        else:
+            logger.error(
+                "CHM footprint clipping enabled but 'in_raster' is missing; continuing without footprint clip."
+            )
+            _log_step(4, step_name, in_count, in_count, skipped_reason="enabled but missing in_raster")
+    else:
+        _log_step(4, step_name, in_count, in_count, skipped_reason="disabled")
 
     step_name = "post-clip normalize + cleanup"
     in_count = len(gdf)

--- a/docs/files/user/check_seed_line.md
+++ b/docs/files/user/check_seed_line.md
@@ -7,7 +7,7 @@
 - normalize multipart lines to `LineString`
 - remove invalid/empty/degenerate geometries
 - optionally remove short lines
-- clip lines to CHM valid-data footprint (with inward shrink)
+- optionally clip lines to CHM valid-data footprint (with inward shrink)
 - optionally snap close endpoints (endpoint-only, directed snap)
 - split lines at intersections
 - optionally group lines and merge by group
@@ -25,7 +25,8 @@
 
 - **Seed Line**: Input seed line file
 - **CHM Raster**: Input raster used to build a valid-data footprint for clipping
-- **CHM footprint shrink (m)**: Inward buffer distance in meters applied before clipping (default `15`). Geographic CRS inputs are converted to a local meter-based projection for this step.
+- **CHM footprint shrink (m)**: Inward buffer distance in meters applied before clipping (default `15`). Geographic CRS inputs are converted to a local meter-based projection for this step. See shrink-distance guide below.
+- **Clip to CHM footprint**: Enable/disable footprint clipping step (default `true`). If enabled and CHM raster is missing, clipping is skipped with an error message.
 - **Output Seed Line**: Output seed line file
 - **Remove short lines**: Enable removal of short segments
 - **Minimum line length (m)**: Threshold in meters for short-line removal (default `5`). Geographic CRS inputs are evaluated in a local meter-based projection for this step.
@@ -41,5 +42,15 @@
 - Input vector and CHM raster should use the same CRS.
 - Works with line data (not points or polygons).
 - If clipping removes all lines, the output may be empty.
+- CHM footprint is generated from raster valid-data cells at raster resolution, so edge boundaries are approximate and can be less accurate.
+- After clipping, visually inspect edge segments and verify that clipped seed lines still match expected line extents.
 - Optional numeric parameters remain visible in the GUI; toggle logic is enforced in backend processing.
 - If CHM footprint shrink is too large, processing fails with guidance to reduce the shrink distance.
+
+## CHM footprint shrink distance guide
+
+- Start with a shrink distance near `1x` to `2x` CHM pixel size (for example, with `1 m` CHM use `1-2 m`; with `5 m` CHM use `5-10 m`).
+- Increase shrink distance when noisy raster edges keep creating false edge segments.
+- Decrease shrink distance when valid lines near canopy boundaries are being clipped too aggressively.
+- For high-resolution CHM, prefer smaller values (`0.5-5 m`) and adjust gradually.
+- For coarser CHM, larger values may be needed, but always verify edge areas visually in the output.

--- a/tests/pytest_qt/test_tool_forms.py
+++ b/tests/pytest_qt/test_tool_forms.py
@@ -60,6 +60,7 @@ class TestCheckSeedLines:
         assert isinstance(_find_widget(tw, "group_lines"), BooleanInput)
         assert isinstance(_find_widget(tw, "merge_by_group"), BooleanInput)
         assert isinstance(_find_widget(tw, "densify_long_lines"), BooleanInput)
+        assert isinstance(_find_widget(tw, "clip_to_chm_footprint"), BooleanInput)
         assert isinstance(_find_widget(tw, "chm_footprint_shrink"), NumericInput)
         assert isinstance(_find_widget(tw, "minimum_line_length"), NumericInput)
         assert isinstance(_find_widget(tw, "snap_tolerance"), NumericInput)
@@ -76,6 +77,7 @@ class TestCheckSeedLines:
                 "in_line": {"path": in_path, "layer": "seed_lines"},
                 "in_raster": str(testdata_dir / "chm_aoi.tif"),
                 "chm_footprint_shrink": 15.0,
+                "clip_to_chm_footprint": True,
                 "out_line": {"path": out_path, "layer": "checked"},
                 "remove_short_lines": True,
                 "minimum_line_length": 5.0,
@@ -93,6 +95,7 @@ class TestCheckSeedLines:
         assert args["in_line"].startswith(f"{in_path}|")
         assert args["in_raster"].endswith("chm_aoi.tif")
         assert args["chm_footprint_shrink"] == pytest.approx(15.0)
+        assert args["clip_to_chm_footprint"] is True
         assert args["out_line"].startswith(f"{out_path}|")
         assert args["remove_short_lines"] is True
         assert args["minimum_line_length"] == pytest.approx(5.0)

--- a/tests/pywinauto/gui_test_config.py
+++ b/tests/pywinauto/gui_test_config.py
@@ -27,6 +27,7 @@ def make_test_data(testdata_dir, output_dir):
                 "path": str(testdata_dir / "chm_aoi.tif"),
             },
             "chm_footprint_shrink": 15.0,
+            "clip_to_chm_footprint": True,
             "out_line": {
                 "path": str(output_dir / "gui_test_output.gpkg"),
                 "layer": "seed_lines_checked",
@@ -149,6 +150,7 @@ PARAM_TYPES = {
     "in_line": {"type": "file", "subtype": "vector"},
     "in_raster": {"type": "file", "subtype": "raster"},
     "chm_footprint_shrink": {"type": "number", "subtype": "float"},
+    "clip_to_chm_footprint": {"type": "list", "subtype": "bool"},
     "out_line": {"type": "file", "subtype": "vector"},
     "remove_short_lines": {"type": "list", "subtype": "bool"},
     "minimum_line_length": {"type": "number", "subtype": "float"},
@@ -197,6 +199,7 @@ TOOL_PARAM_LABELS = {
         "in_line": "Seed Line",
         "in_raster": "CHM Raster",
         "chm_footprint_shrink": "CHM footprint shrink (m)",
+        "clip_to_chm_footprint": "Clip to CHM footprint",
         "out_line": "Output Seed Line",
         "remove_short_lines": "Remove short lines",
         "minimum_line_length": "Minimum line length (m)",

--- a/tests/test_check_seed_line_qc.py
+++ b/tests/test_check_seed_line_qc.py
@@ -334,9 +334,54 @@ def test_check_seed_line_minimum_length_geographic_uses_meters(tmp_path, monkeyp
     assert out.iloc[0]["id"] == 1
 
 
-def test_check_seed_line_requires_in_raster():
-    with pytest.raises(ValueError, match="in_raster"):
-        csl.check_seed_line(in_line="dummy.gpkg|seed", in_raster="", out_line="out.gpkg|seed")
+def test_check_seed_line_missing_raster_logs_error_and_continues(tmp_path, monkeypatch):
+    in_gpkg = _write_seed_input(tmp_path, [LineString([(0.0, 0.0), (1.0, 0.0)])])
+    out_gpkg = tmp_path / "seed_output.gpkg"
+
+    clip_calls = []
+    errors = []
+
+    monkeypatch.setattr(
+        csl, "_clip_to_chm_footprint", lambda gdf, *_args, **_kwargs: clip_calls.append(1) or gdf
+    )
+    monkeypatch.setattr(csl, "qc_split_lines_at_intersections", lambda gdf: gdf)
+    monkeypatch.setattr(csl.logger, "error", lambda msg, *args: errors.append(msg % args if args else msg))
+
+    csl.check_seed_line(
+        in_line=f"{in_gpkg.as_posix()}|seed_lines",
+        in_raster="",
+        out_line=f"{out_gpkg.as_posix()}|seed_checked",
+        clip_to_chm_footprint=True,
+        group_lines=False,
+    )
+
+    out = gpd.read_file(out_gpkg, layer="seed_checked")
+    assert len(out) == 1
+    assert clip_calls == []
+    assert any("in_raster" in msg for msg in errors)
+
+
+def test_check_seed_line_skips_clip_when_disabled(tmp_path, monkeypatch):
+    in_gpkg = _write_seed_input(tmp_path, [LineString([(0.0, 0.0), (1.0, 0.0)])])
+    out_gpkg = tmp_path / "seed_output.gpkg"
+
+    clip_calls = []
+    monkeypatch.setattr(
+        csl, "_clip_to_chm_footprint", lambda gdf, *_args, **_kwargs: clip_calls.append(1) or gdf
+    )
+    monkeypatch.setattr(csl, "qc_split_lines_at_intersections", lambda gdf: gdf)
+
+    csl.check_seed_line(
+        in_line=f"{in_gpkg.as_posix()}|seed_lines",
+        in_raster="",
+        out_line=f"{out_gpkg.as_posix()}|seed_checked",
+        clip_to_chm_footprint=False,
+        group_lines=False,
+    )
+
+    out = gpd.read_file(out_gpkg, layer="seed_checked")
+    assert len(out) == 1
+    assert clip_calls == []
 
 
 def test_pipeline_runs_snap_before_split(tmp_path, monkeypatch):
@@ -398,3 +443,5 @@ def test_schema_marks_chm_shrink_as_optional():
     assert check_tool is not None
     params = {param["variable"]: param for param in check_tool.get("parameters", [])}
     assert params["chm_footprint_shrink"]["optional"] is True
+    assert params["clip_to_chm_footprint"]["default"] is True
+    assert params["clip_to_chm_footprint"]["optional"] is True


### PR DESCRIPTION
This pull request adds a new option to the seed line checking tool to optionally clip lines to the CHM footprint, improves error handling and documentation for this feature, and updates the GUI and tests to support it. The main changes are grouped below:

### Feature Addition: Optional CHM Footprint Clipping

* Added a new parameter `clip_to_chm_footprint` to the tool configuration and GUI, allowing users to enable or disable clipping seed lines to the CHM footprint after inward shrink. This parameter defaults to `true` and is optional. 

### Error Handling and Processing Logic

* Updated processing logic so that if `clip_to_chm_footprint` is enabled but the CHM raster is missing, the tool logs an error and skips the clipping step instead of raising an exception. If clipping is disabled, the step is skipped with a log message. 

### Documentation Improvements

* Updated user documentation to describe the new `clip_to_chm_footprint` option, clarify its default behavior, and provide guidance for shrink distance selection and edge-case handling. 
### Test Updates

* Added and updated tests to verify the new parameter is handled correctly in the GUI, round-trip serialization, and backend processing. Tests now check that clipping is skipped and errors are logged when the raster is missing or clipping is disabled. 
### Schema and GUI Configuration

* Modified tool schema and GUI asset files to mark `clip_to_chm_footprint` and `chm_footprint_shrink` as optional parameters, ensuring correct visibility and toggle logic in the interface. 

Let me know if you have questions about any specific change or want to see how this affects the user workflow!Introduce a new clip_to_chm_footprint boolean parameter to toggle CHM-footprint clipping in the seed-line QC tool.

Close #53 