### PR TITLE
Set float spinbox decimals to 2

### DIFF
--- a/beratools/gui/tool_widgets.py
+++ b/beratools/gui/tool_widgets.py
@@ -786,7 +786,7 @@ class NumericInput(QtWidgets.QWidget):
         elif main_subtype == "float":
             self.data_input = QtWidgets.QDoubleSpinBox()
             self.data_input.setRange(-1e12, 1e12)
-            self.data_input.setDecimals(6)
+            self.data_input.setDecimals(2)
         else:
             if main_subtype is not None:
                 raise ValueError(f"Unsupported parameter type: {main_subtype}")

--- a/tests/pytest_qt/test_tool_widgets.py
+++ b/tests/pytest_qt/test_tool_widgets.py
@@ -93,6 +93,10 @@ class TestNumericInputFloat:
         w = make_numeric_input(self.PARAM)
         assert isinstance(w.data_input, QDoubleSpinBox)
 
+    def test_spinbox_decimals(self, make_numeric_input):
+        w = make_numeric_input(self.PARAM)
+        assert w.data_input.decimals() == 2
+
 
 # ---------------------------------------------------------------------------
 # BooleanInput


### PR DESCRIPTION
This pull request makes a minor adjustment to the decimal precision for floating-point input fields in the GUI, and adds a test to ensure the new precision is enforced.

GUI input behavior changes:

* Reduced the decimal precision of `QDoubleSpinBox` in `tool_widgets.py` from 6 to 2 decimals, making float input fields easier to use for most cases.

Testing improvements:

* Added a unit test to verify that the decimal precision of `QDoubleSpinBox` is set to 2.

Close #51 