### PR TITLE
Add QC aux table persistence for check_seed_line

### DIFF
--- a/beratools/core/algo_common.py
+++ b/beratools/core/algo_common.py
@@ -164,8 +164,16 @@ def save_aux_table(rows, out_file, table, overwrite=True):
         if ds is None:
             raise RuntimeError(f"Unable to open or create GeoPackage: {aux_file}")
 
-        if overwrite and ds.GetLayerByName(table) is not None:
-            ds.DeleteLayer(table)
+        if overwrite:
+            layer_index = -1
+            for idx in range(ds.GetLayerCount()):
+                layer_obj = ds.GetLayer(idx)
+                if layer_obj is not None and layer_obj.GetName() == table:
+                    layer_index = idx
+                    break
+
+            if layer_index >= 0:
+                ds.DeleteLayer(layer_index)
 
         layer = ds.GetLayerByName(table)
         if layer is None:

--- a/beratools/tools/check_seed_line.py
+++ b/beratools/tools/check_seed_line.py
@@ -656,6 +656,15 @@ def check_seed_line(
     aux_file = algo_common.get_aux_path(out_file)
 
     qc_manifest = {
+        "qc_removed_input_cleanup": {
+            "layer_name": "qc_removed_input_cleanup",
+            "step": 0,
+            "step_name": "input cleanup",
+            "reason": "Invalid, null, or empty geometries removed during input hygiene",
+            "feature_count": 0,
+            "written": 0,
+            "notes": "not triggered",
+        },
         "qc_removed_cleanup": {
             "layer_name": "qc_removed_cleanup",
             "step": 2,
@@ -759,12 +768,26 @@ def check_seed_line(
         if not sp_common.compare_crs(sp_common.vector_crs(in_file), sp_common.raster_crs(in_raster)):
             raise ValueError("Input line and raster CRS do not match.")
 
-    gdf = algo_common.read_geospatial_file(in_file, layer=in_layer)
-    if gdf is None:
-        raise ValueError(f"Unable to read input seed lines from: {in_file}")
-
+    gdf = gpd.read_file(in_file, layer=in_layer)
     input_count = len(gdf)
-    logger.info("Seed line QC start: %s feature(s)", len(gdf))
+    gdf = algo_common.clean_geometries(
+        gdf,
+        stage="input",
+        out_file=out_file,
+        layer="qc_removed_input_cleanup",
+    ).reset_index(drop=True)
+    input_cleanup_removed_count = input_count - len(gdf)
+    qc_manifest["qc_removed_input_cleanup"]["feature_count"] = int(max(input_cleanup_removed_count, 0))
+    qc_manifest["qc_removed_input_cleanup"]["written"] = 1 if input_cleanup_removed_count > 0 else 0
+    qc_manifest["qc_removed_input_cleanup"]["notes"] = (
+        "written" if input_cleanup_removed_count > 0 else "empty"
+    )
+
+    logger.info(
+        "Seed line QC start: %s feature(s), input cleanup removed %s feature(s)",
+        len(gdf),
+        input_cleanup_removed_count,
+    )
 
     step_name = "qc_merge_multilinestring"
     in_count = len(gdf)

--- a/tests/test_check_seed_line_qc.py
+++ b/tests/test_check_seed_line_qc.py
@@ -482,6 +482,89 @@ def test_check_seed_line_writes_qc_doc_tables(tmp_path, monkeypatch):
         assert manifest_rows[0][2] == 1
 
 
+def test_check_seed_line_accounts_input_cleanup_in_manifest(tmp_path):
+    in_gpkg = _write_seed_input(
+        tmp_path,
+        [
+            LineString([(0.0, 0.0), (1.0, 0.0)]),
+            None,
+        ],
+        data={"id": [1, 2]},
+    )
+    out_gpkg = tmp_path / "seed_output.gpkg"
+
+    csl.check_seed_line(
+        in_line=f"{in_gpkg.as_posix()}|seed_lines",
+        in_raster="",
+        out_line=f"{out_gpkg.as_posix()}|seed_checked",
+        clip_to_chm_footprint=False,
+        group_lines=False,
+    )
+
+    out = gpd.read_file(out_gpkg, layer="seed_checked")
+    assert len(out) == 1
+
+    aux_gpkg = out_gpkg.with_stem(out_gpkg.stem + "_aux")
+    with sqlite3.connect(aux_gpkg.as_posix()) as conn:
+        row = conn.execute(
+            "SELECT feature_count, written FROM qc_manifest WHERE layer_name='qc_removed_input_cleanup'"
+        ).fetchone()
+        assert row is not None
+        assert row[0] == 1
+        assert row[1] == 1
+
+
+def test_check_seed_line_overwrites_qc_tables_on_rerun(tmp_path, monkeypatch):
+    in_gpkg = _write_seed_input(
+        tmp_path,
+        [
+            LineString([(0.0, 0.0), (1.0, 0.0)]),
+            LineString([(100.0, 100.0), (101.0, 100.0)]),
+        ],
+        data={"id": [1, 2]},
+    )
+    out_gpkg = tmp_path / "seed_output.gpkg"
+
+    monkeypatch.setattr(csl.sp_common, "vector_crs", lambda *_args, **_kwargs: object())
+    monkeypatch.setattr(csl.sp_common, "raster_crs", lambda *_args, **_kwargs: object())
+    monkeypatch.setattr(csl.sp_common, "compare_crs", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(
+        csl.algo_common,
+        "generate_raster_footprint",
+        lambda *_args, **_kwargs: box(-20.0, -20.0, 20.0, 20.0),
+    )
+
+    csl.check_seed_line(
+        in_line=f"{in_gpkg.as_posix()}|seed_lines",
+        in_raster="dummy.tif",
+        out_line=f"{out_gpkg.as_posix()}|seed_checked",
+        clip_to_chm_footprint=False,
+        group_lines=False,
+    )
+
+    csl.check_seed_line(
+        in_line=f"{in_gpkg.as_posix()}|seed_lines",
+        in_raster="dummy.tif",
+        out_line=f"{out_gpkg.as_posix()}|seed_checked",
+        clip_to_chm_footprint=True,
+        group_lines=False,
+    )
+
+    aux_gpkg = out_gpkg.with_stem(out_gpkg.stem + "_aux")
+    with sqlite3.connect(aux_gpkg.as_posix()) as conn:
+        summary_count = conn.execute("SELECT COUNT(*) FROM qc_run_summary").fetchone()[0]
+        output_count = conn.execute("SELECT output_feature_count FROM qc_run_summary").fetchone()[0]
+        clipped = conn.execute(
+            "SELECT feature_count, written FROM qc_manifest WHERE layer_name='qc_removed_clipped'"
+        ).fetchone()
+
+    assert summary_count == 1
+    assert output_count == 1
+    assert clipped is not None
+    assert clipped[0] >= 1
+    assert clipped[1] == 1
+
+
 def test_schema_marks_chm_shrink_as_optional():
     schema_path = Path(__file__).resolve().parents[1] / "beratools" / "gui" / "assets" / "beratools.json"
     data = json.loads(schema_path.read_text(encoding="utf-8"))


### PR DESCRIPTION
This pull request introduces significant improvements to the QC (quality control) and reporting workflow of the `check_seed_line` tool, focusing on better tracking and persistence of removed features and QC steps. It also adds new utility functions for saving tabular QC data, enhances error handling, and improves testability. The most important changes are grouped below:

**QC Tracking and Reporting Enhancements:**

* Introduced a `qc_manifest` dictionary to track features removed at each QC step, with detailed metadata for each removal reason, and added functions to persist this manifest and a QC run summary as auxiliary tables in the output GeoPackage (`save_aux_table`, `_persist_qc_tables`).
* Updated the main QC workflow to capture and save all features removed during cleanup, short line removal, CHM footprint clipping, post-clip cleanup, and final cleanup as separate auxiliary layers, improving traceability and reproducibility of QC steps. 

**Core Utility and API Improvements:**

* Added `save_aux_table` and `_infer_ogr_field_type` functions to `beratools/core/algo_common.py` for saving tabular (non-spatial) QC data to GeoPackage files, supporting various data types and robust error handling.
* Modified `_clean_line_geometries_min_length_m` and `_clip_to_chm_footprint` to return both kept and rejected features, enabling more granular reporting of removed features. 
**Test and Import Adjustments:**

* Updated tests in `tests/test_check_seed_line_qc.py` to patch `generate_raster_footprint` via `algo_common`, ensuring correct test isolation and compatibility with refactored imports. 
* Refactored imports in `beratools/tools/check_seed_line.py` to use `algo_common` consistently, improving code clarity and maintainability. 

**Minor Improvements and Error Handling:**

* Improved handling of empty or invalid input files, with early returns and error messages if the input cannot be read.
* Added more robust CRS handling and GeoDataFrame normalization throughout the QC pipeline. 

**Dependency Updates:**

* Added `ogr` import to `beratools/core/algo_common.py` to support new table-writing utilities.

These changes collectively provide a more transparent, auditable, and robust QC process for seed line processing workflows.

Close #55 