### PR TITLE
Hotfix/test tag on main

### DIFF
--- a/.github/workflows/build-win-installer.yml
+++ b/.github/workflows/build-win-installer.yml
@@ -18,12 +18,31 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Check if tagged commit is on main
+        id: tag_guard
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          $commitSha = if ($env:GITHUB_SHA) { $env:GITHUB_SHA } else { (git rev-parse HEAD).Trim() }
+          git fetch origin main
+          $containsMain = git branch -r --contains "$commitSha" | Select-String 'origin/main'
+
+          if ($containsMain) {
+            "on_main=true" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+            Write-Host "✅ Tag commit is on main. Proceeding with build/release steps."
+          } else {
+            "on_main=false" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+            Write-Host "⏭️ Tag commit is not on main. All build/release steps will be skipped."
+          }
+
       - name: Setup Go
+        if: steps.tag_guard.outputs.on_main == 'true'
         uses: actions/setup-go@v5
         with:
           go-version: "1.21"
 
       - name: Cache Go modules
+        if: steps.tag_guard.outputs.on_main == 'true'
         uses: actions/cache@v4
         with:
           path: ~\go\pkg\mod
@@ -32,17 +51,20 @@ jobs:
             ${{ runner.os }}-go-
 
       - name: Install Inno Setup
+        if: steps.tag_guard.outputs.on_main == 'true'
         run: |
           choco install innosetup -y
         shell: pwsh
 
       - name: Build installer
+        if: steps.tag_guard.outputs.on_main == 'true'
         run: |
           powershell -ExecutionPolicy Bypass -File packaging/build.ps1
         shell: pwsh
         working-directory: ${{ github.workspace }}
 
       - name: Upload installer artifact
+        if: steps.tag_guard.outputs.on_main == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: beratools-installer
@@ -50,7 +72,7 @@ jobs:
           if-no-files-found: error
 
       - name: Upload to release
-        if: ${{ startsWith(github.ref, 'refs/tags/') }}
+        if: steps.tag_guard.outputs.on_main == 'true'
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.ref_name }}

--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -14,20 +14,30 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
-      - name: Verify tag is on main branch
+      - name: Check if tagged commit is on main
+        id: tag_guard
         run: |
+          set -euo pipefail
+          commit_sha="${GITHUB_SHA:-$(git rev-parse HEAD)}"
           git fetch origin main
-          if ! git branch --contains $GITHUB_SHA | grep -q 'main'; then
-            echo "Tag is not from main branch. Skipping publish."
-            exit 0
+          if git branch -r --contains "$commit_sha" | grep -q 'origin/main'; then
+            echo "on_main=true" >> "$GITHUB_OUTPUT"
+            echo "✅ Tag commit is on main. Proceeding with publish steps."
+          else
+            echo "on_main=false" >> "$GITHUB_OUTPUT"
+            echo "⏭️ Tag commit is not on main. All publish steps will be skipped."
           fi
       - name: Set up Python
+        if: steps.tag_guard.outputs.on_main == 'true'
         uses: actions/setup-python@v4
         with:
           python-version: '3.11'
       - name: Install build tools
+        if: steps.tag_guard.outputs.on_main == 'true'
         run: pip install build twine hatch-vcs
       - name: Build package
+        if: steps.tag_guard.outputs.on_main == 'true'
         run: python -m build
       - name: Publish to PyPI
+        if: steps.tag_guard.outputs.on_main == 'true'
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
This pull request improves the safety and consistency of release automation workflows by ensuring that build and publish steps only run if the tagged commit is actually on the `main` branch. This prevents accidental releases from non-main branches. The main changes involve adding a guard step to check branch ancestry and conditionally running subsequent steps in the GitHub Actions workflows for Windows installer, Anaconda, and PyPI publishing.

**Branch ancestry guard and conditional workflow execution:**

* Added a `tag_guard` step to all three workflows (`build-win-installer.yml`, `publish_to_anaconda.yml`, `publish_to_pypi.yml`) that checks if the tagged commit is contained in the `main` branch using either PowerShell or Bash, and sets an output variable accordingly. Steps that perform builds or uploads now run only if this guard passes. 
**Windows installer workflow improvements:**

* Updated all build, install, and upload steps in `.github/workflows/build-win-installer.yml` to run only if the `tag_guard` check confirms the commit is on `main`, preventing accidental releases from other branches.

**Anaconda publish workflow improvements:**

* Updated all setup, build, artifact collection, and upload steps in `.github/workflows/publish_to_anaconda.yml` to run only if the `tag_guard` check confirms the commit is on `main`. This includes the collection of artifacts and uploading to Anaconda.org and GitHub Releases.
* 
**PyPI publish workflow improvements:**

* Updated all setup, build, and publish steps in `.github/workflows/publish_to_pypi.yml` to run only if the `tag_guard` check confirms the commit is on `main`.