### PR TITLE
Enhance version discovery and update tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Install with Anaconda works on Windows, macOS, and Linux.
 - Download the file [environment.yml](https://raw.githubusercontent.com/appliedgrg/beratools/main/environment.yml
 ) and save to local storage. Launch **Anaconda Prompt** or **Miniconda Prompt**.
 - **Change directory** to where environment.yml is saved in the command prompt.
-- Run the following command to create a new environment named **bera**. **BERA Tools** will be installed in the new environment at the same time.
+- Run the following command to create a new environment named **bera**. **BERA Tools** will be installed at the same time.
 
    ```bash
    $ conda env create -n bera -f environment.yml
@@ -54,12 +54,6 @@ Install with Anaconda works on Windows, macOS, and Linux.
     ```bash
     $ conda activate bera
     $ conda update beratools
-    ```
-
-- To completely remove BERA Tools and its environment, run the following command:
-
-    ```bash
-    $ conda remove -n bera
     ```
 
 ## BERA Tools Guide

--- a/beratools/__init__.py
+++ b/beratools/__init__.py
@@ -1,6 +1,6 @@
 __author__ = """AppliedGRG"""
 __email__ = 'appliedgrg@gmail.com'
-__version__ = '0.1.0'
+__version__ = '0.3.3'
 __license__ = "GPL-3.0-or-later"
 __copyright__ = "Copyright (c) AppliedGRG"
 __status__ = "Pre-Alpha"

--- a/beratools/gui/bt_data.py
+++ b/beratools/gui/bt_data.py
@@ -23,6 +23,7 @@ from importlib import metadata as importlib_metadata
 from pathlib import Path
 
 import pyogrio
+from packaging.version import InvalidVersion, Version
 
 import beratools.core.constants as bt_const
 from beratools.gui.geometry_types import (
@@ -51,6 +52,9 @@ def default_callback(value):
 
 def _run_git_command(command, cwd, timeout_s=1.0):
     try:
+        run_kwargs = {}
+        if os.name == "nt":
+            run_kwargs["creationflags"] = getattr(subprocess, "CREATE_NO_WINDOW", 0)
         completed = subprocess.run(
             command,
             cwd=str(cwd),
@@ -58,6 +62,7 @@ def _run_git_command(command, cwd, timeout_s=1.0):
             text=True,
             check=True,
             timeout=timeout_s,
+            **run_kwargs,
         )
         value = completed.stdout.strip()
         return value if value else None
@@ -89,6 +94,64 @@ def _extract_git_revision_from_version(version_value):
 
 def _resolve_git_revision(repo_root):
     return _run_git_command(["git", "rev-parse", "--short", "HEAD"], cwd=repo_root)
+
+
+def _iter_beratools_distributions():
+    for dist in importlib_metadata.distributions():
+        try:
+            dist_name = (dist.metadata.get("Name") or "").strip().lower()
+        except Exception:
+            dist_name = ""
+        if dist_name == "beratools":
+            yield dist
+
+
+def _resolve_metadata_version():
+    candidates = []
+    for dist in _iter_beratools_distributions():
+        raw_version = str(getattr(dist, "version", "")).strip()
+        if not raw_version:
+            continue
+
+        try:
+            normalized = Version(raw_version)
+        except InvalidVersion:
+            _LOG.warning("Skipping BERATools metadata entry with invalid version: %s", raw_version)
+            continue
+
+        dist_path = str(getattr(dist, "_path", ""))
+        sort_key = (dist_path, raw_version)
+        candidates.append(
+            {
+                "raw_version": raw_version,
+                "normalized": normalized,
+                "source": dist_path,
+                "sort_key": sort_key,
+            }
+        )
+
+    if candidates:
+        highest = max(item["normalized"] for item in candidates)
+        highest_candidates = [item for item in candidates if item["normalized"] == highest]
+        winner = sorted(highest_candidates, key=lambda item: item["sort_key"])[0]
+
+        if len(candidates) > 1:
+            discovered = [
+                item["raw_version"] for item in sorted(candidates, key=lambda item: item["sort_key"])
+            ]
+            _LOG.warning(
+                "Detected multiple BERATools metadata versions: %s; selected=%s (source=%s)",
+                discovered,
+                winner["raw_version"],
+                winner["source"] or "unknown",
+            )
+
+        return winner["raw_version"]
+
+    try:
+        return importlib_metadata.version("BERATools")
+    except Exception:
+        return None
 
 
 def _parse_git_version(git_describe, git_revision):
@@ -146,8 +209,17 @@ def _parse_git_version(git_describe, git_revision):
 def get_app_version_info():
     repo_root = Path(__file__).resolve().parents[2]
 
+    override_version = os.getenv("BERATOOLS_APP_VERSION", "").strip()
+    if override_version:
+        version_info = _normalize_version_string(override_version)
+        version_info["git_revision"] = _extract_git_revision_from_version(override_version)
+        _LOG.debug("Resolved app version via BERATOOLS_APP_VERSION")
+        return version_info
+
     try:
-        installed_version = importlib_metadata.version("BERATools")
+        installed_version = _resolve_metadata_version()
+        if not installed_version:
+            raise importlib_metadata.PackageNotFoundError
         version_info = _normalize_version_string(installed_version)
         if not version_info["git_revision"]:
             version_info["git_revision"] = _extract_git_revision_from_version(installed_version)

--- a/beratools/gui/bt_gui_main.py
+++ b/beratools/gui/bt_gui_main.py
@@ -582,16 +582,14 @@ class MainWindow(QtWidgets.QMainWindow):
     def show_about_dialog(self):
         version_info = bt_data.get_app_version_info()
         git_revision = version_info.get("git_revision") or "n/a"
-        release_type = "Release" if version_info.get("is_release") else "Development"
 
         about_text = (
             "BERA Tools\n"
             "Applied Geospatial Research Group (AppliedGRG)\n\n"
             "A suite of geospatial analysis tools for research and operations.\n\n"
             f"Version: {version_info.get('version', 'unknown')}\n"
-            f"Short Version: {version_info.get('short_version', 'unknown')}\n"
             f"Git Revision: {git_revision}\n"
-            f"Build Type: {release_type}\n\n"
+            "\n"
             f"Python: {sys.version.split()[0]}\n"
             f"PyQt: {QtCore.PYQT_VERSION_STR}\n"
             f"Qt: {QtCore.QT_VERSION_STR}\n"

--- a/tests/test_bt_data_version.py
+++ b/tests/test_bt_data_version.py
@@ -1,10 +1,19 @@
-from importlib.metadata import PackageNotFoundError
+import logging
 
+from packaging.version import Version
 from beratools.gui import bt_data
 
 
+class _FakeDist:
+    def __init__(self, version, path):
+        self.version = version
+        self._path = path
+        self.metadata = {"Name": "BERATools"}
+
+
 def test_get_app_version_info_prefers_metadata(monkeypatch):
-    monkeypatch.setattr(bt_data.importlib_metadata, "version", lambda name: "1.2.3")
+    monkeypatch.delenv("BERATOOLS_APP_VERSION", raising=False)
+    monkeypatch.setattr(bt_data, "_resolve_metadata_version", lambda: "1.2.3")
     monkeypatch.setattr(bt_data, "_run_git_command", lambda *args, **kwargs: "v9.9.9-1-gabc123")
 
     info = bt_data.get_app_version_info()
@@ -15,10 +24,8 @@ def test_get_app_version_info_prefers_metadata(monkeypatch):
 
 
 def test_get_app_version_info_handles_no_git(monkeypatch):
-    def _raise_not_found(_name):
-        raise PackageNotFoundError
-
-    monkeypatch.setattr(bt_data.importlib_metadata, "version", _raise_not_found)
+    monkeypatch.delenv("BERATOOLS_APP_VERSION", raising=False)
+    monkeypatch.setattr(bt_data, "_resolve_metadata_version", lambda: None)
     monkeypatch.setattr(bt_data, "_run_git_command", lambda *args, **kwargs: None)
 
     info = bt_data.get_app_version_info()
@@ -29,9 +36,6 @@ def test_get_app_version_info_handles_no_git(monkeypatch):
 
 
 def test_get_app_version_info_from_git_describe_ahead(monkeypatch):
-    def _raise_not_found(_name):
-        raise PackageNotFoundError
-
     def _fake_run_git(command, **_kwargs):
         if command[:2] == ["git", "describe"]:
             return "v1.2.3-4-gabc123"
@@ -39,7 +43,8 @@ def test_get_app_version_info_from_git_describe_ahead(monkeypatch):
             return "abc123"
         return None
 
-    monkeypatch.setattr(bt_data.importlib_metadata, "version", _raise_not_found)
+    monkeypatch.delenv("BERATOOLS_APP_VERSION", raising=False)
+    monkeypatch.setattr(bt_data, "_resolve_metadata_version", lambda: None)
     monkeypatch.setattr(bt_data, "_run_git_command", _fake_run_git)
 
     info = bt_data.get_app_version_info()
@@ -48,3 +53,74 @@ def test_get_app_version_info_from_git_describe_ahead(monkeypatch):
     assert info["short_version"] == "1.2.3"
     assert info["git_revision"] == "abc123"
     assert info["is_release"] is False
+
+
+def test_get_app_version_info_prefers_runtime_override(monkeypatch):
+    monkeypatch.setenv("BERATOOLS_APP_VERSION", "3.4.5")
+    monkeypatch.setattr(bt_data, "_resolve_metadata_version", lambda: "1.2.3")
+    monkeypatch.setattr(bt_data, "_run_git_command", lambda *args, **kwargs: "v9.9.9-1-gabc123")
+
+    info = bt_data.get_app_version_info()
+
+    assert info["version"] == "3.4.5"
+    assert info["short_version"] == "3.4.5"
+
+
+def test_resolve_metadata_version_selects_highest_and_logs_warning(monkeypatch, caplog):
+    dists = [
+        _FakeDist("0.2.5", "C:/env/site-packages/BERATools-0.2.5.dist-info"),
+        _FakeDist("0.3.3", "C:/env/site-packages/BERATools-0.3.3.dist-info"),
+    ]
+    monkeypatch.setattr(bt_data, "_iter_beratools_distributions", lambda: dists)
+
+    with caplog.at_level(logging.WARNING):
+        selected = bt_data._resolve_metadata_version()
+
+    assert selected == "0.3.3"
+    assert "multiple BERATools metadata versions" in caplog.text
+    assert "selected=0.3.3" in caplog.text
+
+
+def test_resolve_metadata_version_tie_breaks_deterministically(monkeypatch, caplog):
+    dists = [
+        _FakeDist("0.3.3", "C:/env/site-packages/z.dist-info"),
+        _FakeDist("0.3.3", "C:/env/site-packages/a.dist-info"),
+    ]
+    monkeypatch.setattr(bt_data, "_iter_beratools_distributions", lambda: dists)
+
+    with caplog.at_level(logging.WARNING):
+        selected = bt_data._resolve_metadata_version()
+
+    assert selected == "0.3.3"
+    assert "source=C:/env/site-packages/a.dist-info" in caplog.text
+
+
+def test_resolve_metadata_version_orders_release_post_dev_local(monkeypatch):
+    versions = ["1.2.3", "1.2.3.post1", "1.2.4.dev1", "1.2.3+local.1"]
+    dists = [_FakeDist(version, f"C:/env/site-packages/{i}.dist-info") for i, version in enumerate(versions)]
+    monkeypatch.setattr(bt_data, "_iter_beratools_distributions", lambda: dists)
+
+    selected = bt_data._resolve_metadata_version()
+
+    expected = max(versions, key=Version)
+    assert selected == expected
+
+
+def test_run_git_command_uses_no_console_flag_on_windows(monkeypatch):
+    captured = {}
+
+    class _Completed:
+        stdout = "abc123\n"
+
+    def _fake_run(*args, **kwargs):
+        captured.update(kwargs)
+        return _Completed()
+
+    monkeypatch.setattr(bt_data.os, "name", "nt")
+    monkeypatch.setattr(bt_data.subprocess, "CREATE_NO_WINDOW", 0x08000000, raising=False)
+    monkeypatch.setattr(bt_data.subprocess, "run", _fake_run)
+
+    value = bt_data._run_git_command(["git", "rev-parse", "--short", "HEAD"], cwd=".")
+
+    assert value == "abc123"
+    assert captured["creationflags"] == 0x08000000


### PR DESCRIPTION
This pull request introduces several improvements and fixes to version detection, metadata handling, and related tests in the `beratools` package. The most notable changes are the implementation of robust logic for resolving the installed version of `BERATools` (especially when multiple distributions are present), improved handling of environment variable overrides for versioning, and expanded test coverage for these scenarios. Additionally, there are minor documentation and UI text updates.

**Version detection and metadata handling:**

* Added `_resolve_metadata_version` and `_iter_beratools_distributions` to robustly determine the installed version of `BERATools`, handling multiple distributions, invalid versions, and tie-breaking by path; emits warnings when multiple versions are found. 
* Updated `get_app_version_info` to support the `BERATOOLS_APP_VERSION` environment variable as an override, and to use the new metadata resolution logic.

**Platform-specific process handling:**

* Modified `_run_git_command` to use the `CREATE_NO_WINDOW` flag on Windows, preventing unwanted console windows when running subprocesses.

**Documentation and UI:**

* Updated the version number in `beratools/__init__.py` to `0.3.3`.
* Minor improvements to the installation instructions in `README.md`, and simplified the "About" dialog text in the GUI.

Close #68 