### PR TITLE
Switch docs build to zensical and use Deploy Pages

### DIFF
--- a/.github/workflows/mkdocs-gh-pages.yml
+++ b/.github/workflows/mkdocs-gh-pages.yml
@@ -1,7 +1,9 @@
-name: Deploy MkDocs to GitHub Pages
+name: Deploy Docs to GitHub Pages
 
 permissions:
-  contents: write
+  contents: read
+  pages: write
+  id-token: write
 
 on:
   pull_request:
@@ -36,12 +38,15 @@ jobs:
           pip install -r docs/files/requirements.txt
       - name: Install project in editable mode
         run: pip install -e .
-      - name: Build MkDocs site
-        run: mkdocs build -f docs/mkdocs.yml
+      - name: Build docs site
+        run: zensical build -f docs/mkdocs.yml
 
   deploy:
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
@@ -59,5 +64,12 @@ jobs:
           pip install -r docs/files/requirements.txt
       - name: Install project in editable mode
         run: pip install -e .
+      - name: Build docs site
+        run: zensical build -f docs/mkdocs.yml
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/site
       - name: Deploy to GitHub Pages
-        run: mkdocs gh-deploy -f docs/mkdocs.yml --force
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/files/requirements.txt
+++ b/docs/files/requirements.txt
@@ -1,5 +1,4 @@
-mkdocs-material
-mkdocs-git-revision-date-localized-plugin
+zensical
 mkdocstrings
 mkdocstrings-python
 pymdown-extensions


### PR DESCRIPTION
This pull request updates the documentation build and deployment workflow to use the `zensical` tool instead of `mkdocs`, and modernizes the GitHub Pages deployment process. The workflow permissions and steps have been revised to align with GitHub's recommended practices for deploying static sites.

**Build and deployment workflow modernization:**

* Changed the workflow to use `zensical` for building the docs site instead of `mkdocs`, including updating the build step and requirements in `docs/files/requirements.txt`. 
* Replaced the direct `mkdocs gh-deploy` command with GitHub's official `actions/upload-pages-artifact@v3` and `actions/deploy-pages@v4` for deploying to GitHub Pages.

**Workflow permissions and environment updates:**

* Updated workflow permissions to use `contents: read`, `pages: write`, and `id-token: write` for improved security and compatibility with GitHub Pages.
* Added explicit deployment environment configuration, including setting the environment name and deployment URL.

Close #74 