### PR TITLE
Add extent/overlap prechecks for spatial tools

### DIFF
--- a/beratools/gui/bt_data.py
+++ b/beratools/gui/bt_data.py
@@ -458,6 +458,7 @@ class BTData(object):
         self.settings = self.settings_manager.settings
         gui_settings = self.settings.get("gui_parameters", {})
         self.recent_tool = gui_settings.get("recent_tool", None)
+        self.selected_cpu_cores = gui_settings.get("selected_cpu_cores", -1)
         if "last_browse_dir" in gui_settings and gui_settings["last_browse_dir"] is not None:
             saved_dir = Path(gui_settings["last_browse_dir"]).expanduser()
             if saved_dir.exists() and saved_dir.is_dir():
@@ -491,7 +492,15 @@ class BTData(object):
             if not data_path.exists():
                 data_path.mkdir()
 
-        self.load_saved_tool_info()
+        # Load settings dict from file without overwriting instance variables
+        if self.setting_file is not None:
+            json_file = Path(self.setting_file)
+            if json_file.exists():
+                with open(json_file, "r") as open_file:
+                    try:
+                        self.settings = json.load(open_file, object_pairs_hook=OrderedDict)
+                    except json.decoder.JSONDecodeError:
+                        pass
 
         if value is not None:
             if "gui_parameters" not in self.settings.keys():
@@ -617,53 +626,6 @@ class BTData(object):
             return ret
         except (OSError, ValueError) as err:
             return err
-
-    def load_saved_tool_info(self):
-        if self.setting_file is not None:
-            data_path = Path(self.setting_file).parent
-            if not data_path.exists():
-                data_path.mkdir()
-
-        saved_parameters = {}
-        if self.setting_file is not None:
-            json_file = Path(self.setting_file)
-            if not json_file.exists():
-                self.settings = saved_parameters
-                return
-            with open(json_file, "r") as open_file:
-                try:
-                    saved_parameters = json.load(open_file, object_pairs_hook=OrderedDict)
-                except json.decoder.JSONDecodeError:
-                    logging.error("Failed to decode settings JSON file of saved tool info.", exc_info=True)
-
-            self.settings = saved_parameters
-        else:
-            self.settings = saved_parameters
-            return
-
-        self.settings = saved_parameters
-
-        # parse file
-        if (
-            isinstance(self.settings, dict)
-            and "gui_parameters" in self.settings
-            and self.settings["gui_parameters"] is not None
-        ):
-            gui_settings = self.settings["gui_parameters"]
-
-            if "selected_cpu_cores" in gui_settings and gui_settings["selected_cpu_cores"] is not None:
-                self.selected_cpu_cores = gui_settings["selected_cpu_cores"]
-
-            if "recent_tool" in gui_settings and gui_settings["recent_tool"] is not None:
-                self.recent_tool = gui_settings["recent_tool"]
-                api_result = self.get_bera_tool_api(self.recent_tool)
-                if not api_result:
-                    self.recent_tool = None
-
-            if "last_browse_dir" in gui_settings and gui_settings["last_browse_dir"] is not None:
-                saved_dir = Path(gui_settings["last_browse_dir"]).expanduser()
-                if saved_dir.exists() and saved_dir.is_dir():
-                    self.last_browse_dir = saved_dir.as_posix()
 
     def set_last_browse_dir(self, path_str):
         if not path_str:

--- a/beratools/gui/bt_gui_main.py
+++ b/beratools/gui/bt_gui_main.py
@@ -254,7 +254,12 @@ class BTSlider(QtWidgets.QWidget):
         self.slider.setTickInterval(2)
         self.slider.setTickPosition(QtWidgets.QSlider.TicksAbove)
         self.slider.setRange(1, maximum)
+
+        # Block signals while setting initial value to avoid triggering save
+        self.slider.blockSignals(True)
         self.slider.setValue(current)
+        self.slider.blockSignals(False)
+
         self.label = QtWidgets.QLabel(self.generate_label_text(current))
 
         layout = QtWidgets.QHBoxLayout()
@@ -370,7 +375,9 @@ class MainWindow(QtWidgets.QMainWindow):
             self.tool_name = self.recent_tool
             self.tool_api = bt.get_bera_tool_api(self.tool_name)
 
-        self.update_procs(bt.get_max_cpu_cores())
+        # Only set to max if not already loaded from saved settings
+        if bt.selected_cpu_cores <= 0:
+            self.update_procs(bt.get_max_cpu_cores())
 
         # QProcess run tools
         self.process = None
@@ -567,7 +574,6 @@ class MainWindow(QtWidgets.QMainWindow):
     def save_tool_parameter(self):
         # Retrieve tool parameters from GUI
         args = self.tool_widget.get_widgets_arguments()
-        # bt.load_saved_tool_info()
         bt.add_tool_history(self.tool_api, args)
         bt.save_tool_info()
 

--- a/beratools/gui/tool_widgets.py
+++ b/beratools/gui/tool_widgets.py
@@ -302,21 +302,14 @@ class ToolWidgets(QtWidgets.QWidget):
                 continue
 
             if isinstance(widget, BooleanInput):
-                text_width = widget.checkbox.fontMetrics().horizontalAdvance(
-                    widget.checkbox.text()
-                )
+                text_width = widget.checkbox.fontMetrics().horizontalAdvance(widget.checkbox.text())
                 if not checkbox_indicator_overhead:
                     style = widget.checkbox.style()
                     opt = QtWidgets.QStyleOptionButton()
                     opt.initFrom(widget.checkbox)
-                    checkbox_indicator_overhead = (
-                        style.pixelMetric(
-                            QtWidgets.QStyle.PM_IndicatorWidth, opt, widget.checkbox
-                        )
-                        + style.pixelMetric(
-                            QtWidgets.QStyle.PM_CheckBoxLabelSpacing, opt, widget.checkbox
-                        )
-                    )
+                    checkbox_indicator_overhead = style.pixelMetric(
+                        QtWidgets.QStyle.PM_IndicatorWidth, opt, widget.checkbox
+                    ) + style.pixelMetric(QtWidgets.QStyle.PM_CheckBoxLabelSpacing, opt, widget.checkbox)
                 anchor_width = max(anchor_width, text_width + checkbox_indicator_overhead + 8)
             elif isinstance(label, QtWidgets.QLabel):
                 anchor_width = max(anchor_width, label.sizeHint().width())
@@ -598,16 +591,22 @@ class FileSelector(QtWidgets.QWidget):
         # Populate combo box if vector and file exists
         if self.is_vector and self.value["path"] and Path(self.value["path"]).exists():
             try:
+                requested_layer = self.value.get("layer", "")
                 layers_dict = get_layers(self.value["path"])
+                self.layer_combo.blockSignals(True)
                 self.layer_combo.clear()
                 for layer_name, geometry_type in layers_dict.items():
                     self.layer_combo.addItem(f"{layer_name} ({geometry_type})")
                 self.layer_combo.setVisible(True)
-                if self.value["layer"]:
-                    index = self.layer_combo.findText(self.value["layer"])
+                if requested_layer:
+                    index = self._find_layer_index_by_name(requested_layer)
                     if index >= 0:
                         self.layer_combo.setCurrentIndex(index)
+                        self.value["layer"] = requested_layer
+                self.layer_combo.blockSignals(False)
+                self.set_layer(self.layer_combo.currentText())
             except Exception:
+                self.layer_combo.blockSignals(False)
                 self.layer_combo.clear()
                 self.layer_combo.setVisible(False)
         self.in_file.textChanged.connect(self.file_name_edited)
@@ -695,6 +694,25 @@ class FileSelector(QtWidgets.QWidget):
         default_name = self._unique_layer_name("Result_layer")
         self.layer_combo.addItem(default_name)
 
+    @staticmethod
+    def _layer_name_from_combo_text(combo_text):
+        if not combo_text or combo_text == FileSelector.NO_COMPATIBLE_LAYER_TEXT:
+            return ""
+        if " (" in combo_text:
+            return combo_text.split(" (", 1)[0]
+        return combo_text
+
+    def _find_layer_index_by_name(self, layer_name):
+        target = (layer_name or "").strip()
+        if not target:
+            return -1
+
+        for index in range(self.layer_combo.count()):
+            if self._layer_name_from_combo_text(self.layer_combo.itemText(index)) == target:
+                return index
+
+        return -1
+
     def _on_vector_path_changed(self, path, is_output, selected_layer=""):
         is_gpkg = bool(path) and path.lower().endswith(".gpkg")
         if not is_gpkg:
@@ -712,7 +730,7 @@ class FileSelector(QtWidgets.QWidget):
                 if is_output and self.layer_combo.isEditable():
                     self.layer_combo.setCurrentText(selected_layer)
                 else:
-                    index = self.layer_combo.findText(selected_layer)
+                    index = self._find_layer_index_by_name(selected_layer)
                     if index >= 0:
                         self.layer_combo.setCurrentIndex(index)
             self.layer_combo.adjustSize()

--- a/beratools/tools/canopy_footprint_absolute.py
+++ b/beratools/tools/canopy_footprint_absolute.py
@@ -100,6 +100,19 @@ def canopy_footprint_abs(
         "Maximum Line Width (m)",
     )
 
+    if not sp_common.compare_crs(vec_crs_osr, sp_common.raster_crs(request.in_chm)):
+        print("Line and CHM have different spatial references, please check.")
+        return
+
+    if not sp_common.check_vector_raster_extent_overlap(in_file, in_layer, request.in_chm):
+        print("Input line extent does not overlap input raster extent.")
+        return
+
+    line_gdf = gpd.read_file(in_file, layer=in_layer)
+    if not sp_common.check_vector_raster_overlap(line_gdf, request.in_chm):
+        print("Input line(s) do not overlap input raster.")
+        return
+
     if mode == "adaptive":
         result = _run_adaptive_request(request)
         rejected_layer_name = "rejected_output_canopy_footprint_adaptive"

--- a/beratools/tools/centerline.py
+++ b/beratools/tools/centerline.py
@@ -16,6 +16,7 @@ Description:
 import logging
 from pathlib import Path
 
+import geopandas as gpd
 import pandas as pd
 
 import beratools.core.algo_centerline as algo_centerline
@@ -119,6 +120,15 @@ def centerline(
 
     if not sp_common.compare_crs(vec_crs_osr, sp_common.raster_crs(in_raster)):
         print("Line and CHM have different spatial references, please check.")
+        return
+
+    if not sp_common.check_vector_raster_extent_overlap(in_file, in_layer, in_raster):
+        print("Input line extent does not overlap input raster extent.")
+        return
+
+    line_gdf = gpd.read_file(in_file, layer=in_layer)
+    if not sp_common.check_vector_raster_overlap(line_gdf, in_raster):
+        print("Input line(s) do not overlap input raster.")
         return
 
     line_class_list = generate_line_class_list(

--- a/beratools/tools/ground_footprint.py
+++ b/beratools/tools/ground_footprint.py
@@ -289,6 +289,10 @@ def ground_footprint(
     offset = float(offset)
     width_percentile = int(width_percentile)
 
+    if not sp_common.check_vector_vector_extent_overlap(in_file, in_layer, in_fp_file, in_layer_fp):
+        print("Input line extent does not overlap input footprint extent.")
+        return
+
     # TODO: refactor this code for better line quality check
     line_gdf = gpd.read_file(in_file, layer=in_layer)
     if "fid" in line_gdf.columns:
@@ -328,6 +332,16 @@ def ground_footprint(
     poly_gdf = algo_common.clean_geometries(poly_gdf, stage="input")
     poly_gdf = poly_gdf.reset_index(drop=True)
     poly_gdf["geometry"] = poly_gdf["geometry"].apply(algo_common.remove_holes)
+
+    if not sp_common.compare_crs(
+        sp_common.vector_crs(in_file, in_layer), sp_common.vector_crs(in_fp_file, in_layer_fp)
+    ):
+        print("Input line and footprint have different spatial references, please check.")
+        return
+
+    if not sp_common.check_vector_vector_overlap(line_gdf, poly_gdf):
+        print("Input line(s) do not overlap input footprint.")
+        return
 
     # merge group and/or split lines at intersections
     merged_line_gdf = line_gdf.copy(deep=True)

--- a/beratools/utility/spatial_common.py
+++ b/beratools/utility/spatial_common.py
@@ -380,4 +380,7 @@ def check_vector_vector_overlap(gdf1, gdf2) -> bool:
 
 def seedlines_within_chm_footprint(gdf, in_raster) -> bool:
     """Check whether seed lines overlap the CHM raster footprint."""
+    if gdf is None or gdf.empty:
+        return True
+
     return check_vector_raster_overlap(gdf, in_raster)

--- a/beratools/utility/spatial_common.py
+++ b/beratools/utility/spatial_common.py
@@ -19,7 +19,7 @@ import geopandas as gpd
 import numpy as np
 import pyproj
 import rasterio
-from osgeo import gdal, osr, version_info
+from osgeo import gdal, ogr, osr, version_info
 from pyogrio import set_gdal_config_options
 from rasterio import mask
 
@@ -113,14 +113,14 @@ def decode_file_layer(encoded):
     return file_path, layer_name
 
 
-def vector_crs(in_vector,gpd_layer):
+def vector_crs(in_vector, gpd_layer):
     osr_crs = osr.SpatialReference()
     from pyproj.enums import WktVersion
 
     vec_crs = None
     # open input vector data as GeoDataFrame
-    if gpd_layer!=None:
-        gpd_vector = gpd.GeoDataFrame.from_file(in_vector,layer=gpd_layer)
+    if gpd_layer != None:
+        gpd_vector = gpd.GeoDataFrame.from_file(in_vector, layer=gpd_layer)
     else:
         gpd_vector = gpd.GeoDataFrame.from_file(in_vector)
     try:
@@ -221,15 +221,163 @@ def compare_crs(crs_org, crs_dst):
     return False
 
 
-def seedlines_within_chm_footprint(gdf, in_raster) -> bool:
-    """Check whether seed lines overlap the CHM raster footprint."""
+def _extents_overlap(ext1, ext2) -> bool:
+    """Return whether two extents overlap."""
+    minx1, miny1, maxx1, maxy1 = ext1
+    minx2, miny2, maxx2, maxy2 = ext2
+    return not (maxx1 < minx2 or minx1 > maxx2 or maxy1 < miny2 or miny1 > maxy2)
+
+
+def _vector_extent_from_gpkg_contents(in_vector, layer_name):
+    """Read vector extent from GeoPackage metadata when available."""
+    ds = ogr.Open(in_vector)
+    if ds is None:
+        return None
+
+    try:
+        target_layer = layer_name
+        if target_layer is None:
+            layer0 = ds.GetLayerByIndex(0)
+            if layer0 is None:
+                return None
+            target_layer = layer0.GetName()
+
+        layer_sql_name = target_layer.replace("'", "''")
+        sql = f"SELECT min_x, min_y, max_x, max_y FROM gpkg_contents WHERE table_name = '{layer_sql_name}'"
+        result = ds.ExecuteSQL(sql)
+        if result is None:
+            return None
+
+        try:
+            feat = result.GetNextFeature()
+            if feat is None:
+                return None
+
+            min_x = feat.GetField("min_x")
+            min_y = feat.GetField("min_y")
+            max_x = feat.GetField("max_x")
+            max_y = feat.GetField("max_y")
+            if None in (min_x, min_y, max_x, max_y):
+                return None
+
+            return float(min_x), float(min_y), float(max_x), float(max_y)
+        finally:
+            ds.ReleaseResultSet(result)
+    finally:
+        ds = None
+
+
+def get_vector_extent_fast(in_vector, layer_name=None):
+    """Get vector extent with metadata-first strategy and safe fallback."""
+    extent = None
+
+    if str(in_vector).lower().endswith(".gpkg"):
+        extent = _vector_extent_from_gpkg_contents(in_vector, layer_name)
+        if extent is not None:
+            return extent
+
+    ds = ogr.Open(in_vector)
+    if ds is None:
+        return None
+
+    try:
+        layer = ds.GetLayerByName(layer_name) if layer_name else ds.GetLayerByIndex(0)
+        if layer is None:
+            return None
+
+        extent_ogr = layer.GetExtent(force=0)
+        if extent_ogr is None:
+            extent_ogr = layer.GetExtent(force=1)
+        if extent_ogr is None:
+            return None
+
+        min_x, max_x, min_y, max_y = extent_ogr
+        return float(min_x), float(min_y), float(max_x), float(max_y)
+    finally:
+        ds = None
+
+
+def get_raster_extent(in_raster):
+    """Get raster extent as (minx, miny, maxx, maxy)."""
+    with rasterio.open(in_raster) as raster_file:
+        bounds = raster_file.bounds
+        return float(bounds.left), float(bounds.bottom), float(bounds.right), float(bounds.top)
+
+
+def check_vector_raster_extent_overlap(in_vector, in_layer, in_raster) -> bool:
+    """Fast extent precheck for vector/raster overlap.
+
+    Returns False only for definite disjoint extents. Returns True when overlap
+    exists or extents cannot be determined.
+    """
+    vector_extent = get_vector_extent_fast(in_vector, in_layer)
+    raster_extent = get_raster_extent(in_raster)
+
+    if vector_extent is None or raster_extent is None:
+        return True
+
+    return _extents_overlap(vector_extent, raster_extent)
+
+
+def check_vector_vector_extent_overlap(in_vector1, in_layer1, in_vector2, in_layer2) -> bool:
+    """Fast extent precheck for vector/vector overlap.
+
+    Returns False only for definite disjoint extents. Returns True when overlap
+    exists or extents cannot be determined.
+    """
+    extent1 = get_vector_extent_fast(in_vector1, in_layer1)
+    extent2 = get_vector_extent_fast(in_vector2, in_layer2)
+
+    if extent1 is None or extent2 is None:
+        return True
+
+    return _extents_overlap(extent1, extent2)
+
+
+def check_vector_raster_overlap(gdf, in_raster) -> bool:
+    """Check whether vector geometries overlap a raster footprint."""
     from beratools.core.algo_common import generate_raster_footprint
 
-    footprint = generate_raster_footprint(in_raster, latlon=False)
-    if not footprint.is_empty and all(footprint.contains(gdf["geometry"])):
-        return True
-    elif not footprint.is_empty and any(footprint.intersects(gdf["geometry"])):
-        print("[Warning]: Some seedlines are partially intersect the CHM footprint.")
-        return True
-    else:
+    if gdf is None or gdf.empty:
         return False
+
+    geometries = gdf["geometry"]
+    footprint = generate_raster_footprint(in_raster, latlon=False)
+
+    if footprint.is_empty:
+        return False
+
+    if all(footprint.contains(geometries)):
+        return True
+
+    if any(footprint.intersects(geometries)):
+        print("[Warning]: Some input features are partially outside the raster footprint.")
+        return True
+
+    return False
+
+
+def check_vector_vector_overlap(gdf1, gdf2) -> bool:
+    """Check whether vector geometries in gdf1 overlap those in gdf2."""
+    if gdf1 is None or gdf1.empty or gdf2 is None or gdf2.empty:
+        return False
+
+    geom1 = gdf1["geometry"]
+    union2 = gdf2.geometry.union_all()
+
+    if union2 is None or union2.is_empty:
+        return False
+
+    if all(union2.contains(geom1)):
+        return True
+
+    if any(union2.intersects(geom1)):
+        print("[Warning]: Some input features are partially outside the reference footprint.")
+        return True
+
+    return False
+
+
+def seedlines_within_chm_footprint(gdf, in_raster) -> bool:
+    """Check whether seed lines overlap the CHM raster footprint."""
+    return check_vector_raster_overlap(gdf, in_raster)

--- a/tests/pytest_qt/test_tool_widgets.py
+++ b/tests/pytest_qt/test_tool_widgets.py
@@ -546,6 +546,24 @@ class TestFileSelectorLayerComboInteraction:
         w.layer_combo.setCurrentText("centerline (MultiLineString)")
         assert w.value["layer"] == "centerline"
 
+    def test_saved_layer_name_restores_when_combo_items_include_geometry_suffix(
+        self, make_file_selector, patched_layers, tmp_path
+    ):
+        gpkg = str(tmp_path / "input.gpkg")
+        Path(gpkg).write_text("", encoding="utf-8")
+        patched_layers.return_value = {
+            "seed_line_checked_kirby": "LineString",
+            "seed_line_checked_bohn": "MultiLineString",
+        }
+
+        param = dict(self.VECTOR_PARAM)
+        param["saved_value"] = f"{gpkg}|seed_line_checked_bohn"
+
+        w = make_file_selector(param)
+
+        assert w.value["layer"] == "seed_line_checked_bohn"
+        assert w.layer_combo.currentText().startswith("seed_line_checked_bohn")
+
     @pytest.mark.parametrize(
         ("ext", "expected_visible"),
         [(".gpkg", True), (".shp", False)],

--- a/tests/test_algo_centerline_modes.py
+++ b/tests/test_algo_centerline_modes.py
@@ -1,5 +1,6 @@
 import pytest
 from pathlib import Path
+import geopandas as gpd
 import pyproj
 from shapely.geometry import LineString, Point, Polygon
 
@@ -298,6 +299,18 @@ def test_centerline_tool_converts_line_radius_meters_to_projected_native_units(m
         lambda *_args, **_kwargs: object(),
     )
     monkeypatch.setattr("beratools.tools.centerline.sp_common.compare_crs", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(
+        "beratools.tools.centerline.gpd.read_file",
+        lambda *_args, **_kwargs: gpd.GeoDataFrame(geometry=[LineString([(0, 0), (1, 0)])], crs="EPSG:2263"),
+    )
+    monkeypatch.setattr(
+        "beratools.tools.centerline.sp_common.check_vector_raster_overlap",
+        lambda *_args, **_kwargs: True,
+    )
+    monkeypatch.setattr(
+        "beratools.tools.centerline.sp_common.check_vector_raster_extent_overlap",
+        lambda *_args, **_kwargs: True,
+    )
 
     def _fake_generate(
         _in_file, _in_raster, line_radius, layer=None, proc_segments=True, guided_strategy=None
@@ -344,3 +357,130 @@ def test_centerline_tool_rejects_geographic_crs_for_meter_radius(monkeypatch):
             proc_segments=True,
             out_line="out.gpkg|centerline",
         )
+
+
+def test_centerline_tool_terminates_when_lines_do_not_overlap_raster(monkeypatch):
+    from beratools.tools.centerline import centerline
+
+    class _FakeOSR:
+        def ExportToWkt(self):
+            return pyproj.CRS.from_epsg(2263).to_wkt()
+
+    monkeypatch.setattr(
+        "beratools.tools.centerline.sp_common.vector_crs", lambda *_args, **_kwargs: _FakeOSR()
+    )
+    monkeypatch.setattr("beratools.tools.centerline.sp_common.raster_crs", lambda *_args, **_kwargs: object())
+    monkeypatch.setattr("beratools.tools.centerline.sp_common.compare_crs", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(
+        "beratools.tools.centerline.gpd.read_file",
+        lambda *_args, **_kwargs: gpd.GeoDataFrame(geometry=[LineString([(0, 0), (1, 0)])], crs="EPSG:2263"),
+    )
+    monkeypatch.setattr(
+        "beratools.tools.centerline.sp_common.check_vector_raster_overlap",
+        lambda *_args, **_kwargs: False,
+    )
+    monkeypatch.setattr(
+        "beratools.tools.centerline.sp_common.check_vector_raster_extent_overlap",
+        lambda *_args, **_kwargs: True,
+    )
+
+    called = {"generate": 0}
+
+    def _fake_generate(*_args, **_kwargs):
+        called["generate"] += 1
+        raise RuntimeError("should-not-be-called")
+
+    monkeypatch.setattr("beratools.tools.centerline.generate_line_class_list", _fake_generate)
+
+    result = centerline(
+        in_line="dummy.gpkg|line",
+        in_raster="dummy.tif",
+        line_radius=10.0,
+        proc_segments=True,
+        out_line="out.gpkg|centerline",
+    )
+
+    assert result is None
+    assert called["generate"] == 0
+
+
+def test_centerline_tool_continues_when_lines_partially_overlap_raster(monkeypatch):
+    from beratools.tools.centerline import centerline
+
+    class _FakeOSR:
+        def ExportToWkt(self):
+            return pyproj.CRS.from_epsg(2263).to_wkt()
+
+    monkeypatch.setattr(
+        "beratools.tools.centerline.sp_common.vector_crs", lambda *_args, **_kwargs: _FakeOSR()
+    )
+    monkeypatch.setattr("beratools.tools.centerline.sp_common.raster_crs", lambda *_args, **_kwargs: object())
+    monkeypatch.setattr("beratools.tools.centerline.sp_common.compare_crs", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(
+        "beratools.tools.centerline.gpd.read_file",
+        lambda *_args, **_kwargs: gpd.GeoDataFrame(geometry=[LineString([(0, 0), (1, 0)])], crs="EPSG:2263"),
+    )
+    monkeypatch.setattr(
+        "beratools.tools.centerline.sp_common.check_vector_raster_overlap",
+        lambda *_args, **_kwargs: True,
+    )
+    monkeypatch.setattr(
+        "beratools.tools.centerline.sp_common.check_vector_raster_extent_overlap",
+        lambda *_args, **_kwargs: True,
+    )
+
+    called = {"generate": 0}
+
+    def _fake_generate(*_args, **_kwargs):
+        called["generate"] += 1
+        return []
+
+    monkeypatch.setattr("beratools.tools.centerline.generate_line_class_list", _fake_generate)
+
+    result = centerline(
+        in_line="dummy.gpkg|line",
+        in_raster="dummy.tif",
+        line_radius=10.0,
+        proc_segments=True,
+        out_line="out.gpkg|centerline",
+    )
+
+    assert result == 1
+    assert called["generate"] == 1
+
+
+def test_centerline_tool_terminates_on_extent_precheck_without_loading_features(monkeypatch):
+    from beratools.tools.centerline import centerline
+
+    class _FakeOSR:
+        def ExportToWkt(self):
+            return pyproj.CRS.from_epsg(2263).to_wkt()
+
+    monkeypatch.setattr(
+        "beratools.tools.centerline.sp_common.vector_crs", lambda *_args, **_kwargs: _FakeOSR()
+    )
+    monkeypatch.setattr("beratools.tools.centerline.sp_common.raster_crs", lambda *_args, **_kwargs: object())
+    monkeypatch.setattr("beratools.tools.centerline.sp_common.compare_crs", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(
+        "beratools.tools.centerline.sp_common.check_vector_raster_extent_overlap",
+        lambda *_args, **_kwargs: False,
+    )
+
+    called = {"read": 0}
+
+    def _fake_read(*_args, **_kwargs):
+        called["read"] += 1
+        raise RuntimeError("should-not-read")
+
+    monkeypatch.setattr("beratools.tools.centerline.gpd.read_file", _fake_read)
+
+    result = centerline(
+        in_line="dummy.gpkg|line",
+        in_raster="dummy.tif",
+        line_radius=10.0,
+        proc_segments=True,
+        out_line="out.gpkg|centerline",
+    )
+
+    assert result is None
+    assert called["read"] == 0

--- a/tests/test_canopy_footprint_absolute_tool.py
+++ b/tests/test_canopy_footprint_absolute_tool.py
@@ -1,0 +1,128 @@
+import geopandas as gpd
+import pyproj
+from shapely.geometry import LineString
+
+import beratools.tools.canopy_footprint_absolute as cfa
+
+
+class _FakeOSR:
+    def ExportToWkt(self):
+        return pyproj.CRS.from_epsg(2263).to_wkt()
+
+
+def _line_gdf():
+    return gpd.GeoDataFrame(geometry=[LineString([(0.0, 0.0), (5.0, 0.0)])], crs="EPSG:2263")
+
+
+def _patch_common_guards(monkeypatch, overlap_result):
+    monkeypatch.setattr(cfa.sp_common, "vector_crs", lambda *_args, **_kwargs: _FakeOSR())
+    monkeypatch.setattr(cfa.sp_common, "raster_crs", lambda *_args, **_kwargs: object())
+    monkeypatch.setattr(cfa.sp_common, "compare_crs", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(
+        cfa.unit_conversion, "convert_meters_param_projected_from_osr", lambda *_args, **_kwargs: 32.0
+    )
+    monkeypatch.setattr(cfa.gpd, "read_file", lambda *_args, **_kwargs: _line_gdf())
+    monkeypatch.setattr(cfa.sp_common, "check_vector_raster_extent_overlap", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(
+        cfa.sp_common, "check_vector_raster_overlap", lambda *_args, **_kwargs: overlap_result
+    )
+
+
+def test_canopy_footprint_absolute_stops_when_no_line_raster_overlap(monkeypatch):
+    _patch_common_guards(monkeypatch, overlap_result=False)
+
+    called = {"run": 0}
+
+    def _fake_run(*_args, **_kwargs):
+        called["run"] += 1
+        raise RuntimeError("should-not-run")
+
+    monkeypatch.setattr(cfa, "_run_absolute_request", _fake_run)
+
+    result = cfa.canopy_footprint_abs(
+        in_line="line.gpkg|line",
+        in_chm="chm.tif",
+        out_footprint="out.gpkg|footprint",
+        footprint_mode="absolute",
+    )
+
+    assert result is None
+    assert called["run"] == 0
+
+
+def test_canopy_footprint_absolute_continues_when_partial_overlap(monkeypatch):
+    _patch_common_guards(monkeypatch, overlap_result=True)
+
+    called = {"run": 0}
+
+    def _fake_run(*_args, **_kwargs):
+        called["run"] += 1
+        return cfa.CanopyFootprintResult(messages=[])
+
+    monkeypatch.setattr(cfa, "_run_absolute_request", _fake_run)
+    monkeypatch.setattr(cfa, "save_main_footprint", lambda *_args, **_kwargs: True)
+
+    cfa.canopy_footprint_abs(
+        in_line="line.gpkg|line",
+        in_chm="chm.tif",
+        out_footprint="out.gpkg|footprint",
+        footprint_mode="absolute",
+    )
+
+    assert called["run"] == 1
+
+
+def test_canopy_footprint_adaptive_stops_when_no_line_raster_overlap(monkeypatch):
+    _patch_common_guards(monkeypatch, overlap_result=False)
+
+    called = {"run": 0}
+
+    def _fake_run(*_args, **_kwargs):
+        called["run"] += 1
+        raise RuntimeError("should-not-run")
+
+    monkeypatch.setattr(cfa, "_run_adaptive_request", _fake_run)
+
+    result = cfa.canopy_footprint_abs(
+        in_line="line.gpkg|line",
+        in_chm="chm.tif",
+        out_footprint="out.gpkg|footprint",
+        footprint_mode="adaptive",
+    )
+
+    assert result is None
+    assert called["run"] == 0
+
+
+def test_canopy_footprint_stops_on_extent_precheck_without_loading_features(monkeypatch):
+    monkeypatch.setattr(cfa.sp_common, "vector_crs", lambda *_args, **_kwargs: _FakeOSR())
+    monkeypatch.setattr(cfa.sp_common, "raster_crs", lambda *_args, **_kwargs: object())
+    monkeypatch.setattr(cfa.sp_common, "compare_crs", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(
+        cfa.unit_conversion, "convert_meters_param_projected_from_osr", lambda *_args, **_kwargs: 32.0
+    )
+    monkeypatch.setattr(cfa.sp_common, "check_vector_raster_extent_overlap", lambda *_args, **_kwargs: False)
+
+    called = {"read": 0, "run": 0}
+
+    def _fake_read(*_args, **_kwargs):
+        called["read"] += 1
+        raise RuntimeError("should-not-read")
+
+    def _fake_run(*_args, **_kwargs):
+        called["run"] += 1
+        raise RuntimeError("should-not-run")
+
+    monkeypatch.setattr(cfa.gpd, "read_file", _fake_read)
+    monkeypatch.setattr(cfa, "_run_absolute_request", _fake_run)
+
+    result = cfa.canopy_footprint_abs(
+        in_line="line.gpkg|line",
+        in_chm="chm.tif",
+        out_footprint="out.gpkg|footprint",
+        footprint_mode="absolute",
+    )
+
+    assert result is None
+    assert called["read"] == 0
+    assert called["run"] == 0

--- a/tests/test_check_seed_line_qc.py
+++ b/tests/test_check_seed_line_qc.py
@@ -463,6 +463,31 @@ def test_check_seed_line_raises_when_seedlines_do_not_overlap_raster(tmp_path, m
         )
 
 
+def test_check_seed_line_allows_empty_input_with_clip_to_chm_enabled(tmp_path, monkeypatch):
+    in_gpkg = _write_seed_input(tmp_path, [], data={"id": []})
+    out_gpkg = tmp_path / "seed_output.gpkg"
+
+    monkeypatch.setattr(csl.sp_common, "vector_crs", lambda *_args, **_kwargs: object())
+    monkeypatch.setattr(csl.sp_common, "raster_crs", lambda *_args, **_kwargs: object())
+    monkeypatch.setattr(csl.sp_common, "compare_crs", lambda *_args, **_kwargs: True)
+
+    csl.check_seed_line(
+        in_line=f"{in_gpkg.as_posix()}|seed_lines",
+        in_raster="dummy.tif",
+        out_line=f"{out_gpkg.as_posix()}|seed_checked",
+        clip_to_chm_footprint=True,
+        group_lines=False,
+    )
+
+    out = gpd.read_file(out_gpkg, layer="seed_checked")
+    assert out.empty
+
+    aux_gpkg = out_gpkg.with_stem(out_gpkg.stem + "_aux")
+    with sqlite3.connect(aux_gpkg.as_posix()) as conn:
+        output_count = conn.execute("SELECT output_feature_count FROM qc_run_summary").fetchone()[0]
+    assert output_count == 0
+
+
 def test_check_seed_line_assigns_unique_bt_group_when_grouping_disabled(tmp_path, monkeypatch):
     in_gpkg = _write_seed_input(
         tmp_path,

--- a/tests/test_ground_footprint_units.py
+++ b/tests/test_ground_footprint_units.py
@@ -47,6 +47,10 @@ def _run_ground_footprint_until_prepare_line_args(monkeypatch, line_crs):
     monkeypatch.setattr(gf.gpd, "read_file", _fake_read_file)
     monkeypatch.setattr(gf.algo_common, "clean_geometries", lambda gdf, **_kwargs: gdf)
     monkeypatch.setattr(gf.algo_common, "remove_holes", lambda geom: geom)
+    monkeypatch.setattr(gf.sp_common, "vector_crs", lambda *_args, **_kwargs: object())
+    monkeypatch.setattr(gf.sp_common, "compare_crs", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(gf.sp_common, "check_vector_vector_extent_overlap", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(gf.sp_common, "check_vector_vector_overlap", lambda *_args, **_kwargs: True)
     monkeypatch.setattr(gf, "LineGrouping", _DummyLineGrouping)
     monkeypatch.setattr(gf, "prepare_line_args", _fake_prepare_line_args)
 
@@ -91,3 +95,80 @@ def test_ground_footprint_rejects_geographic_crs_for_meter_length(monkeypatch):
             merge_group=True,
             trim_output=False,
         )
+
+
+def test_ground_footprint_stops_when_line_and_footprint_do_not_overlap(monkeypatch):
+    line_gdf = gpd.GeoDataFrame(
+        {"BT_GROUP": [1]},
+        geometry=[LineString([(0.0, 0.0), (1.0, 0.0)])],
+        crs="EPSG:2263",
+    )
+    fp_gdf = gpd.GeoDataFrame(
+        {"BT_GROUP": [1]},
+        geometry=[Polygon([(100.0, 100.0), (110.0, 100.0), (110.0, 110.0), (100.0, 110.0)])],
+        crs="EPSG:2263",
+    )
+
+    def _fake_read_file(path, layer=None, **_kwargs):
+        if path == "line.gpkg" and layer == "line":
+            return line_gdf.copy()
+        if path == "line.gpkg" and layer == "least_cost_path":
+            raise pyogrio.errors.DataLayerError("missing")
+        if path == "fp.gpkg" and layer == "fp":
+            return fp_gdf.copy()
+        raise ValueError(f"unexpected read_file call: {path}|{layer}")
+
+    called = {"prepare": 0}
+
+    def _fake_prepare_line_args(*_args, **_kwargs):
+        called["prepare"] += 1
+        raise RuntimeError("should-not-run")
+
+    monkeypatch.setattr(gf.gpd, "read_file", _fake_read_file)
+    monkeypatch.setattr(gf.algo_common, "clean_geometries", lambda gdf, **_kwargs: gdf)
+    monkeypatch.setattr(gf.algo_common, "remove_holes", lambda geom: geom)
+    monkeypatch.setattr(gf.sp_common, "vector_crs", lambda *_args, **_kwargs: object())
+    monkeypatch.setattr(gf.sp_common, "compare_crs", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(gf.sp_common, "check_vector_vector_extent_overlap", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(gf.sp_common, "check_vector_vector_overlap", lambda *_args, **_kwargs: False)
+    monkeypatch.setattr(gf, "prepare_line_args", _fake_prepare_line_args)
+
+    result = gf.ground_footprint(
+        in_line="line.gpkg|line",
+        in_footprint="fp.gpkg|fp",
+        n_samples=10,
+        offset=10.0,
+        max_width=True,
+        out_footprint="out.gpkg|ground",
+        merge_group=True,
+        trim_output=False,
+    )
+
+    assert result is None
+    assert called["prepare"] == 0
+
+
+def test_ground_footprint_stops_on_extent_precheck_without_loading_features(monkeypatch):
+    monkeypatch.setattr(gf.sp_common, "check_vector_vector_extent_overlap", lambda *_args, **_kwargs: False)
+
+    called = {"read": 0}
+
+    def _fake_read(*_args, **_kwargs):
+        called["read"] += 1
+        raise RuntimeError("should-not-read")
+
+    monkeypatch.setattr(gf.gpd, "read_file", _fake_read)
+
+    result = gf.ground_footprint(
+        in_line="line.gpkg|line",
+        in_footprint="fp.gpkg|fp",
+        n_samples=10,
+        offset=10.0,
+        max_width=True,
+        out_footprint="out.gpkg|ground",
+        merge_group=True,
+        trim_output=False,
+    )
+
+    assert result is None
+    assert called["read"] == 0


### PR DESCRIPTION
This pull request introduces robust spatial overlap and extent prechecks to the canopy footprint, centerline, and ground footprint tools, enhancing their reliability and efficiency. The changes ensure that operations are only performed when input geometries and rasters have compatible spatial references and overlapping extents, preventing unnecessary computation and improving error handling. Additionally, comprehensive tests have been added to validate these behaviors.

Spatial overlap and extent prechecks:

* Added fast extent prechecks (`check_vector_raster_extent_overlap`, `check_vector_vector_extent_overlap`) and geometry overlap checks (`check_vector_raster_overlap`, `check_vector_vector_overlap`) to `beratools/utility/spatial_common.py`, including efficient metadata-based extent retrieval and improved warning messages for partial overlaps.
* Updated `canopy_footprint_abs` (`beratools/tools/canopy_footprint_absolute.py`), `centerline` (`beratools/tools/centerline.py`), and `ground_footprint` (`beratools/tools/ground_footprint.py`) to perform CRS comparison, extent prechecks, and geometry overlap checks before loading features or running algorithms, terminating early if checks fail. 

Testing and validation:

* Added and expanded tests for all tools to verify correct termination when spatial references or extents do not match, and to ensure that features are not unnecessarily loaded or processed when overlap checks fail (`tests/test_algo_centerline_modes.py`, `tests/test_canopy_footprint_absolute_tool.py`, `tests/test_ground_footprint_units.py`). 

These improvements make the tools more robust against invalid or mismatched spatial inputs and provide clearer error messages to users.

Closes #77.