### PR TITLE
Feature/add codesign

### DIFF
--- a/.github/workflows/build-win-installer.yml
+++ b/.github/workflows/build-win-installer.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: windows-latest
     permissions:
       contents: write
+      actions: read
 
     steps:
       - name: Checkout repository
@@ -25,6 +26,12 @@ jobs:
         shell: pwsh
         run: |
           $ErrorActionPreference = "Stop"
+          if ($env:GITHUB_EVENT_NAME -eq "workflow_dispatch") {
+            "on_main=true" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+            Write-Host "Manual workflow_dispatch run. Proceeding with build/sign test."
+            exit 0
+          }
+
           $commitSha = if ($env:GITHUB_SHA) { $env:GITHUB_SHA } else { (git rev-parse HEAD).Trim() }
           git fetch origin main
           $containsMain = git branch -r --contains "$commitSha" | Select-String 'origin/main'
@@ -65,19 +72,42 @@ jobs:
         shell: pwsh
         working-directory: ${{ github.workspace }}
 
-      - name: Upload installer artifact
+      - name: Upload unsigned installer for signing
+        id: upload-unsigned-installer
         if: steps.tag_guard.outputs.on_main == 'true'
         uses: actions/upload-artifact@v4
         with:
-          name: beratools-installer
+          name: beratools-installer-unsigned
           path: packaging/dist/beratools-installer-*.exe
           if-no-files-found: error
 
-      - name: Upload to release
+      - name: Submit installer to SignPath
         if: steps.tag_guard.outputs.on_main == 'true'
-        uses: softprops/action-gh-release@v2
+        uses: signpath/github-action-submit-signing-request@v2
         with:
-          tag_name: ${{ github.ref_name }}
-          files: packaging/dist/beratools-installer-*.exe
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
+          organization-id: ${{ secrets.SIGNPATH_ORGANIZATION_ID }}
+          project-slug: beratools
+          signing-policy-slug: test-signing
+          github-artifact-id: ${{ steps.upload-unsigned-installer.outputs.artifact-id }}
+          wait-for-completion: true
+          output-artifact-directory: packaging/dist-signed
+
+      - name: Verify signed installer
+        if: steps.tag_guard.outputs.on_main == 'true'
+        shell: pwsh
+        run: |
+          $installer = Get-ChildItem packaging/dist-signed/beratools-installer-*.exe | Select-Object -First 1
+          $sig = Get-AuthenticodeSignature $installer.FullName
+          $sig | Format-List
+          if ($sig.SignerCertificate -eq $null -or $sig.Status -eq "NotSigned") {
+            throw "Installer was not signed."
+          }
+
+      - name: Upload signed installer artifact
+        if: steps.tag_guard.outputs.on_main == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: beratools-installer-signed
+          path: packaging/dist-signed/beratools-installer-*.exe
+          if-no-files-found: error

--- a/.github/workflows/build-win-installer.yml
+++ b/.github/workflows/build-win-installer.yml
@@ -46,13 +46,13 @@ jobs:
 
       - name: Setup Go
         if: steps.tag_guard.outputs.on_main == 'true'
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: "1.21"
 
       - name: Cache Go modules
         if: steps.tag_guard.outputs.on_main == 'true'
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~\go\pkg\mod
           key: ${{ runner.os }}-go-${{ hashFiles('packaging/go.sum') }}
@@ -75,7 +75,7 @@ jobs:
       - name: Upload unsigned installer for signing
         id: upload-unsigned-installer
         if: steps.tag_guard.outputs.on_main == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: beratools-installer-unsigned
           path: packaging/dist/beratools-installer-*.exe
@@ -106,7 +106,7 @@ jobs:
 
       - name: Upload signed installer artifact
         if: steps.tag_guard.outputs.on_main == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: beratools-installer-signed
           path: packaging/dist-signed/beratools-installer-*.exe

--- a/.github/workflows/build-win-installer.yml
+++ b/.github/workflows/build-win-installer.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: windows-2022
     permissions:
       contents: write
       actions: read

--- a/.github/workflows/build-win-installer.yml
+++ b/.github/workflows/build-win-installer.yml
@@ -15,44 +15,52 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           token: ${{ github.token }}
           persist-credentials: true
           fetch-depth: 0
 
-      - name: Check if tagged commit is on main
-        id: tag_guard
+      - name: Select signing policy
+        id: signing
         shell: pwsh
         run: |
           $ErrorActionPreference = "Stop"
           if ($env:GITHUB_EVENT_NAME -eq "workflow_dispatch") {
-            "on_main=true" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
-            Write-Host "Manual workflow_dispatch run. Proceeding with build/sign test."
+            "enabled=true" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+            "signing_policy=test-signing" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+            "publish_release=false" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+            Write-Host "Manual run: building with the test-signing policy."
             exit 0
           }
 
-          $commitSha = if ($env:GITHUB_SHA) { $env:GITHUB_SHA } else { (git rev-parse HEAD).Trim() }
-          git fetch origin main
-          $containsMain = git branch -r --contains "$commitSha" | Select-String 'origin/main'
+          $commitSha = (git rev-parse "$env:GITHUB_SHA^{commit}").Trim()
+          git fetch --no-tags origin main:refs/remotes/origin/main
+          git merge-base --is-ancestor $commitSha origin/main
+          $mergeBaseResult = $LASTEXITCODE
 
-          if ($containsMain) {
-            "on_main=true" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
-            Write-Host "✅ Tag commit is on main. Proceeding with build/release steps."
+          if ($mergeBaseResult -eq 0) {
+            "enabled=true" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+            "signing_policy=release-signing" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+            "publish_release=true" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+            Write-Host "Tag commit is on main. Building with the release-signing policy."
+          } elseif ($mergeBaseResult -eq 1) {
+            "enabled=false" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+            "publish_release=false" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+            Write-Host "Tag commit is not on main. Build and signing steps will be skipped."
           } else {
-            "on_main=false" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
-            Write-Host "⏭️ Tag commit is not on main. All build/release steps will be skipped."
+            throw "Unable to determine whether $commitSha is on main."
           }
 
       - name: Setup Go
-        if: steps.tag_guard.outputs.on_main == 'true'
-        uses: actions/setup-go@v6
+        if: steps.signing.outputs.enabled == 'true'
+        uses: actions/setup-go@v7
         with:
           go-version: "1.21"
 
       - name: Cache Go modules
-        if: steps.tag_guard.outputs.on_main == 'true'
-        uses: actions/cache@v5
+        if: steps.signing.outputs.enabled == 'true'
+        uses: actions/cache@v6
         with:
           path: ~\go\pkg\mod
           key: ${{ runner.os }}-go-${{ hashFiles('packaging/go.sum') }}
@@ -60,54 +68,92 @@ jobs:
             ${{ runner.os }}-go-
 
       - name: Install Inno Setup
-        if: steps.tag_guard.outputs.on_main == 'true'
+        if: steps.signing.outputs.enabled == 'true'
         run: |
           choco install innosetup -y
         shell: pwsh
 
       - name: Build installer
-        if: steps.tag_guard.outputs.on_main == 'true'
+        id: build-installer
+        if: steps.signing.outputs.enabled == 'true'
         run: |
           powershell -ExecutionPolicy Bypass -File packaging/build.ps1
+
+          $installers = @(Get-ChildItem packaging/dist/beratools-installer-*.exe -File)
+          if ($installers.Count -ne 1) {
+            throw "Expected one unsigned installer, found $($installers.Count)."
+          }
+
+          if ($installers[0].BaseName -notmatch '^beratools-installer-(\d+\.\d+\.\d+(?:\.\d+)?)$') {
+            throw "Installer filename does not contain a supported version: $($installers[0].Name)"
+          }
+
+          "version=$($Matches[1])" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
         shell: pwsh
         working-directory: ${{ github.workspace }}
 
       - name: Upload unsigned installer for signing
         id: upload-unsigned-installer
-        if: steps.tag_guard.outputs.on_main == 'true'
-        uses: actions/upload-artifact@v6
+        if: steps.signing.outputs.enabled == 'true'
+        uses: actions/upload-artifact@v7
         with:
           name: beratools-installer-unsigned
           path: packaging/dist/beratools-installer-*.exe
           if-no-files-found: error
 
       - name: Submit installer to SignPath
-        if: steps.tag_guard.outputs.on_main == 'true'
+        if: steps.signing.outputs.enabled == 'true'
         uses: signpath/github-action-submit-signing-request@v2
         with:
           api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
           organization-id: ${{ secrets.SIGNPATH_ORGANIZATION_ID }}
           project-slug: beratools
-          signing-policy-slug: test-signing
+          signing-policy-slug: ${{ steps.signing.outputs.signing_policy }}
           github-artifact-id: ${{ steps.upload-unsigned-installer.outputs.artifact-id }}
+          parameters: |
+            version: ${{ toJSON(steps.build-installer.outputs.version) }}
           wait-for-completion: true
+          wait-for-completion-timeout-in-seconds: 3600
           output-artifact-directory: packaging/dist-signed
 
       - name: Verify signed installer
-        if: steps.tag_guard.outputs.on_main == 'true'
+        if: steps.signing.outputs.enabled == 'true'
         shell: pwsh
+        env:
+          SIGNING_POLICY: ${{ steps.signing.outputs.signing_policy }}
         run: |
-          $installer = Get-ChildItem packaging/dist-signed/beratools-installer-*.exe | Select-Object -First 1
+          $installers = @(Get-ChildItem packaging/dist-signed/beratools-installer-*.exe -File)
+          if ($installers.Count -ne 1) {
+            throw "Expected one signed installer, found $($installers.Count)."
+          }
+
+          $installer = $installers[0]
           $sig = Get-AuthenticodeSignature $installer.FullName
           $sig | Format-List
-          if ($sig.SignerCertificate -eq $null -or $sig.Status -eq "NotSigned") {
+          if ($null -eq $sig.SignerCertificate -or $sig.Status -eq "NotSigned") {
             throw "Installer was not signed."
           }
 
+          if ($env:SIGNING_POLICY -eq "release-signing" -and $sig.Status -ne "Valid") {
+            throw "Release signature is not valid: $($sig.Status) - $($sig.StatusMessage)"
+          }
+
       - name: Upload signed installer artifact
-        if: steps.tag_guard.outputs.on_main == 'true'
-        uses: actions/upload-artifact@v6
+        if: steps.signing.outputs.enabled == 'true'
+        uses: actions/upload-artifact@v7
         with:
           name: beratools-installer-signed
           path: packaging/dist-signed/beratools-installer-*.exe
           if-no-files-found: error
+
+      - name: Upload signed installer to release
+        if: steps.signing.outputs.publish_release == 'true'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          files: packaging/dist-signed/beratools-installer-*.exe
+          body: |
+            Windows installer signed under the [BERA Tools Code signing policy](https://github.com/appliedgrg/beratools/blob/main/CODE_SIGNING_POLICY.md).
+          append_body: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CODE_SIGNING_POLICY.md
+++ b/CODE_SIGNING_POLICY.md
@@ -1,0 +1,18 @@
+# Code signing policy
+
+Free code signing is provided by [SignPath.io](https://about.signpath.io/), certificate by [SignPath Foundation](https://signpath.org/).
+
+## Team roles
+
+- Committers and reviewers: [AppliedGRG developers](https://github.com/orgs/appliedgrg/teams/developers)
+- Approvers: [AppliedGRG administrators](https://github.com/orgs/appliedgrg/teams/admin)
+
+## Release process
+
+Official Windows installers are built by GitHub Actions from version tags whose commits are on the `main` branch. SignPath verifies the build origin and requires an authorized approver to approve each `release-signing` request before the installer is published.
+
+Manual GitHub Actions runs use the `test-signing` policy and do not use the release certificate.
+
+## Privacy
+
+This program will not transfer any information to other networked systems unless specifically requested by the user or the person installing or operating it.

--- a/CODE_SIGNING_POLICY.md
+++ b/CODE_SIGNING_POLICY.md
@@ -11,7 +11,9 @@ Free code signing is provided by [SignPath.io](https://about.signpath.io/), cert
 
 Official Windows installers are built by GitHub Actions from version tags whose commits are on the `main` branch. SignPath verifies the build origin and requires an authorized approver to approve each `release-signing` request before the installer is published.
 
-Manual GitHub Actions runs use the `test-signing` policy and do not use the release certificate.
+Manual GitHub Actions runs use the `test-signing` policy, do not require signing approval, and do not use the release certificate. Release signing uses a separate policy that requires an authorized approver.
+
+Maintainers can find test-signing and release instructions in [Publishing BERA Tools](docs/files/developer/publishing.md#windows-installer-signing).
 
 ## Privacy
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Here are the ways to install BERA Tools:
 
 ### Windows Installer
 
-Windows installer is provided with releases. Check the [latest release](https://github.com/appliedgrg/beratools/releases/latest).
+Windows installer is provided with releases. Check the [latest release](https://github.com/appliedgrg/beratools/releases/latest). Official Windows installers are signed under the BERA Tools [Code signing policy](CODE_SIGNING_POLICY.md).
 
 ### Install with Anaconda
 
@@ -56,6 +56,21 @@ For more information about installation, check the [BERA Tools Installation](htt
 ## BERA Tools Guide
 
 Check the online [BERA Tools Guide](https://appliedgrg.github.io/beratools/) for user, developer and technical guides.
+
+## Sponsors
+
+<table>
+  <tr>
+    <td align="center">
+      <a href="https://about.signpath.io/">
+        <img src="https://avatars.githubusercontent.com/u/34448643?s=48&amp;v=4" alt="SignPath logo" width="48">
+      </a>
+    </td>
+    <td>
+      Free code signing on Windows provided by <a href="https://about.signpath.io/">SignPath.io</a>, certificate by <a href="https://signpath.org/">SignPath Foundation</a>.
+    </td>
+  </tr>
+</table>
 
 ## Credits
 

--- a/docs/files/developer/maintainer.md
+++ b/docs/files/developer/maintainer.md
@@ -55,6 +55,11 @@ Here is a summary of the actions defined in all workflow files in `.github/workf
     - Trigger: Manually triggered via `workflow_dispatch`.
     - Builds the package and publishes to TestPyPI.
 
+- __build-win-installer.yml__
+    - Summary: Builds the Windows installer and submits it to SignPath using `test-signing`.
+    - Trigger: Manually triggered via `workflow_dispatch` on the selected branch.
+    - Does not require signing approval and uploads unsigned and test-signed Actions artifacts without publishing a GitHub Release.
+
 ### Version tag push
 
 - __publish_to_anaconda.yml__
@@ -67,6 +72,13 @@ Here is a summary of the actions defined in all workflow files in `.github/workf
     - Trigger: On version tag push from `main`.
     - Builds the package and publishes to PyPI.
 
+- __build-win-installer.yml__
+    - Summary: Builds the Windows installer and submits it to SignPath using `release-signing`.
+    - Trigger: On a version tag push whose commit is in `main`.
+    - Waits for SignPath approval, verifies the formal signature, and attaches the signed installer to the GitHub Release.
+
+See [Publishing BERA Tools](publishing.md#windows-installer-signing) for the signing and release procedure.
+
 ### Configuration
 
 There are security measures in place to restrict actions to be used. Find these in: Repository Settings -> Actions -> General --> Actions permissions:
@@ -76,6 +88,8 @@ There are security measures in place to restrict actions to be used. Find these 
 GitHub has been configured to use repository secrets for sensitive information such as API tokens and credentials required by the workflows. Find these in: Repository Settings -> Secrets and variables -> Actions --> Repository secrets:
 
 ![Actions](../screenshots/gh_repo_secrets.png)  
+
+Windows signing requires the `SIGNPATH_API_TOKEN` and `SIGNPATH_ORGANIZATION_ID` repository secrets. The SignPath action must also remain allowed under Repository Settings -> Actions -> General -> Actions permissions. Secret values must never be added to source control or documentation.
 
 ### Actions Flow
 
@@ -92,19 +106,26 @@ flowchart LR
 
     CheckType -->|Manual trigger| Manual[Workflow Dispatch]
     Manual --> PyPITest[Test PyPI]
+    Manual --> InstallerTest[Windows Installer Test]
+    InstallerTest --> TestSign[SignPath test-signing]
+    TestSign --> SignedTest[Signed Actions Artifact]
     
     CheckType -->|Version tag| Release[Release]
     Release --> Anaconda[Conda]
     Release --> PyPI[PyPI]
+    Release --> WindowsInstaller[Windows Installer]
+    WindowsInstaller --> SignPathApproval[SignPath Approval]
+    SignPathApproval --> SignedRelease[Signed GitHub Release]
     
     classDef push fill:#e1f5ff,stroke:#01579b
     classDef pr fill:#fff3e0,stroke:#e65100
+    classDef manual fill:#f3e5f5,stroke:#6a1b9a
     classDef rel fill:#e8f5e9,stroke:#2e7d32
     
     class Mkdocs,Pytest push
-    class PyPITest manual
+    class PyPITest,InstallerTest,TestSign,SignedTest manual
     class Tox pr
-    class Anaconda,PyPI rel
+    class Anaconda,PyPI,WindowsInstaller,SignPathApproval,SignedRelease rel
 ```
 
 ## Secure our repository

--- a/docs/files/developer/publishing.md
+++ b/docs/files/developer/publishing.md
@@ -1,13 +1,13 @@
 # Publishing BERA Tools
 
-BERA Tools is published to Conda and Pypi when main brach is tagged by new version.
+BERA Tools is published to Conda and PyPI when the `main` branch is tagged with a new version. The same tag builds, signs, and publishes the Windows installer.
 
 ## Versioning
 
 BERA Tools Versioning follows [PEP440](https://peps.python.org/pep-0440/): `major.minor.patch`.
 
 | Versions | Description |
-|-----------|--------------|
+| --- | --- |
 | **Major** | This is reserved for releases that introduce breaking features. |
 | **Minor** | This is reserved for releases that introduce new functionality. |
 | **Patch** | This is reserved for releases that only include bug fixes. |
@@ -21,8 +21,82 @@ See the following workflows:
 - Conda Packaging and Release: [publish_to_anaconda.yml](https://github.com/appliedgrg/beratools/blob/main/.github/workflows/publish_to_anaconda.yml)
 - PyPI Packaging and Release: [publish_to_pypi.yml](https://github.com/appliedgrg/beratools/blob/main/.github/workflows/publish_to_pypi.yml)
 - TestPyPI Packaging (manual): [publish_to_pypi_test.yml](https://github.com/appliedgrg/beratools/blob/main/.github/workflows/publish_to_pypi_test.yml)
+- Windows Installer Build and Signing: [build-win-installer.yml](https://github.com/appliedgrg/beratools/blob/main/.github/workflows/build-win-installer.yml)
 
-See two actions details in [Maintainer Guide](maintainer.md#version-tag-push).
+See the workflow inventory in the [Maintainer Guide](maintainer.md#actions).
+
+## Windows Installer Signing
+
+Official Windows installers follow the project [Code signing policy](https://github.com/appliedgrg/beratools/blob/main/CODE_SIGNING_POLICY.md). Test and release signing use the same SignPath artifact configuration so a manual test validates the artifact that will later be released.
+
+| Trigger | Signing policy | Approval | Result |
+| --- | --- | --- | --- |
+| Manual `workflow_dispatch` | `test-signing` | Disabled by policy | Signed GitHub Actions artifact only |
+| Version tag on a commit in `main` | `release-signing` | One approval required | Signed artifact and GitHub Release |
+| Version tag outside `main` | None | None | Build and signing steps are skipped |
+
+### Manual Signing Test
+
+Run a test after changing the installer, its build script, the signing workflow, or the SignPath artifact configuration.
+
+1. Open [Build Windows Installer](https://github.com/appliedgrg/beratools/actions/workflows/build-win-installer.yml) in GitHub Actions.
+2. Select **Run workflow** and choose the branch to test.
+3. Wait for the `Submit installer to SignPath` step to complete using `test-signing`.
+4. Confirm the run contains both `beratools-installer-unsigned` and `beratools-installer-signed` artifacts.
+5. Confirm `Upload signed installer to release` was skipped.
+
+The test certificate is self-signed, so `Get-AuthenticodeSignature` may report `UnknownError` because its root is not trusted by Windows. The workflow still requires a signer certificate and rejects an unsigned installer. Test-signed installers are for validation only and must not be distributed as releases.
+
+### Production Release
+
+1. Merge the release changes into `main` and ensure all release workflows are ready.
+2. Create a `major.minor.patch` version tag on a commit in `main` and push the tag.
+3. Monitor the [Build Windows Installer](https://github.com/appliedgrg/beratools/actions/workflows/build-win-installer.yml) run.
+4. Open the signing request from the SignPath email or the URL printed by the workflow.
+5. An authorized SignPath approver must approve the request within the workflow's one-hour timeout.
+6. Confirm the release signature status is `Valid`.
+7. Confirm the signed installer was attached to the GitHub Release.
+
+The person who creates the tag does not need to be a SignPath approver. With multiple approvers and one required approval, any listed approver can authorize the request. If the request is denied or times out, the workflow does not publish the installer.
+
+### SignPath Configuration
+
+Open **Projects -> beratools -> Signing policies** in SignPath to review policy settings.
+
+| Setting | `test-signing` | `release-signing` |
+| --- | --- | --- |
+| Certificate | Self-signed test certificate | Active SignPath Foundation release certificate |
+| Submitter | `CI builds` | `CI builds` |
+| Approval process | Disabled | Enabled; one approval required |
+| Intended origin | Branch selected for the manual test | `main` only |
+| Allowed build definition | `.github/workflows/build-win-installer.yml` | `.github/workflows/build-win-installer.yml` |
+| Result | Actions artifact only | Approved GitHub Release |
+
+For `release-signing`, require trusted-build-system verification and origin verification. Set the repository URL to `https://github.com/appliedgrg/beratools.git`, the allowed branch to `main`, and the allowed build definition to `.github/workflows/build-win-installer.yml`.
+
+Both policies use the default artifact configuration below. Only these artifact rules are shared; certificates, approval requirements, branch restrictions, and origin settings remain policy-specific.
+
+```xml
+<?xml version="1.0" encoding="utf-8" ?>
+<artifact-configuration xmlns="http://signpath.io/artifact-configuration/v1">
+  <parameters>
+    <parameter name="version" required="true" />
+  </parameters>
+  <zip-file>
+    <pe-file path="beratools-installer-${version}.exe">
+      <authenticode-sign />
+    </pe-file>
+  </zip-file>
+</artifact-configuration>
+```
+
+Inno Setup pads text fields in the PE version resource. Do not add `product-name`, `product-version`, or `file-version` restrictions without confirming a supported configuration with SignPath and completing a manual signing test.
+
+The GitHub workflow reads `SIGNPATH_API_TOKEN` and `SIGNPATH_ORGANIZATION_ID` from repository Actions secrets. Never expose secret values, organization identifiers, user email addresses, or signing-request URLs in documentation or source control.
+
+For maintainer handoff, add replacement users as SignPath approvers and retain at least one organization administrator or project configurator. With multiple approvers and one required approval, any listed approver can approve. Require MFA, keep the `CI builds` submitter independent of personal accounts, and verify replacement access before removing a departing maintainer.
+
+After any portal or artifact-configuration change, run the manual signing test. The message `No GitHub policy found at .signpath/policies/...` is informational when no repository policy file is configured; open the signing request in SignPath for actual processing failures.
 
 ## Releases
 

--- a/docs/files/index.md
+++ b/docs/files/index.md
@@ -13,6 +13,10 @@ high-resolution CHMs allow for improved forest line spatial analysis.
 
 This tool is part of the [**Boreal Ecosystem Recovery and Assessment (BERA)**](http://www.beraproject.org/) Project, and is being actively developed by the [**Applied Geospatial Research Group**](https://www.appliedgrg.ca/).
 
+## Code signing policy
+
+Official BERA Tools Windows installers are signed according to the project [Code signing policy](https://github.com/appliedgrg/beratools/blob/main/CODE_SIGNING_POLICY.md).
+
 ### Cite Us
 
 If you use BERA Tools for a publication, please cite it as:

--- a/docs/files/user/installation.md
+++ b/docs/files/user/installation.md
@@ -13,6 +13,26 @@ Welcome to **BERA Tools**! This guide will give you advanced installation option
 
 Download the standalone Windows installer from the [latest BERA Tools release](https://github.com/appliedgrg/beratools/releases/latest). Official installers are signed according to the project [Code signing policy](https://github.com/appliedgrg/beratools/blob/main/CODE_SIGNING_POLICY.md).
 
+Only installers attached to an official GitHub Release are intended for users. Artifacts from manual signing tests use a self-signed test certificate and must not be distributed.
+
+#### Verify the Installer Signature
+
+Before running a downloaded installer on Windows:
+
+1. Right-click the installer and select **Properties**.
+2. Open the **Digital Signatures** tab.
+3. Select the SignPath Foundation signature and click **Details**.
+4. Confirm Windows reports **This digital signature is OK**.
+
+You can also verify the installer with PowerShell:
+
+```powershell
+Get-AuthenticodeSignature .\beratools-installer-x.y.z.exe |
+    Format-List Status, StatusMessage, SignerCertificate, TimeStamperCertificate
+```
+
+For an official release, `Status` must be `Valid`. Do not run the installer if the signature is missing or invalid.
+
 ### Using conda
 
 Have Miniconda installed on your system, then create an environment from the provided [environment.yml](https://raw.githubusercontent.com/appliedgrg/beratools/main/environment.yml):
@@ -48,7 +68,7 @@ beratools
 
 This will start the main GUI.
 
-## Advanced Installation
+## Install From Source
 
 [Developer Guide](../developer_guide.md) — Detailed instructions for installing from source, running tests, and contributing.
 

--- a/docs/files/user/installation.md
+++ b/docs/files/user/installation.md
@@ -9,6 +9,10 @@ Welcome to **BERA Tools**! This guide will give you advanced installation option
 
 ## Installation Methods
 
+### Windows Installer
+
+Download the standalone Windows installer from the [latest BERA Tools release](https://github.com/appliedgrg/beratools/releases/latest). Official installers are signed according to the project [Code signing policy](https://github.com/appliedgrg/beratools/blob/main/CODE_SIGNING_POLICY.md).
+
 ### Using conda
 
 Have Miniconda installed on your system, then create an environment from the provided [environment.yml](https://raw.githubusercontent.com/appliedgrg/beratools/main/environment.yml):

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -6,9 +6,9 @@ recipe.yaml
 
 ## Windows installer
 
-build.ps1
-beratools.iss
-main.go
+- `build.ps1`: assembles the embedded Python environment, application files, and launcher, then invokes Inno Setup.
+- `beratools.iss`: defines the installer layout and Windows version metadata.
+- `main.go`: builds the Windows GUI launcher included in the installer.
 
 ## Build locally
 
@@ -18,4 +18,6 @@ Run the following command to build the Windows installer locally:
 .\build.ps1
 ```
 
-This will generate the installer in the `dist` directory. `build` folder store all temporary files during the build process.
+This generates the installer in the `dist` directory. The `build` folder stores temporary files created during the build process.
+
+Local builds are unsigned. Official installers are built and signed by the [Build Windows Installer workflow](../.github/workflows/build-win-installer.yml); no signing certificate or private key is stored in this repository. See [Windows Installer Signing](../docs/files/developer/publishing.md#windows-installer-signing) for manual test signing and production release instructions, and see the project [Code signing policy](../CODE_SIGNING_POLICY.md) for signing roles and privacy commitments.

--- a/packaging/beratools.iss
+++ b/packaging/beratools.iss
@@ -7,6 +7,10 @@
 AppName=BERA Tools
 WizardImageFile=..\beratools\gui\assets\BERA_WizardImage.png
 AppVersion={#MyAppVersion}
+VersionInfoVersion={#MyAppVersion}
+VersionInfoProductName=BERA Tools
+VersionInfoProductVersion={#MyAppVersion}
+VersionInfoProductTextVersion={#MyAppVersion}
 DefaultDirName={commonpf}\BERA Tools
 DefaultGroupName=BERA Tools
 OutputDir=dist


### PR DESCRIPTION
This pull request introduces a comprehensive Windows code signing policy for BERA Tools and overhauls the Windows installer build workflow to support secure, automated, and policy-driven code signing. It also adds documentation and acknowledgments for the new code signing process and its sponsor. The most important changes are grouped below:

**Build and Release Workflow Modernization:**

* Major update to `.github/workflows/build-win-installer.yml`: The workflow now supports conditional code signing using SignPath, distinguishes between release and test signing, verifies signatures, and only publishes installers signed under the correct policy. Steps and actions are upgraded, and artifact handling is improved for both unsigned and signed installers.

**Documentation and Policy:**

* Added `CODE_SIGNING_POLICY.md`: Documents the code signing process, team roles, release criteria, and privacy assurances for signed Windows installers.
* Updated `README.md` to reference the code signing policy for Windows installers and added a Sponsors section acknowledging SignPath Foundation for providing free code signing. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L26-R26) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R60-R74)
* Updated `docs/files/index.md` and `docs/files/user/installation.md` to mention and link to the new code signing policy for official Windows installers. [[1]](diffhunk://#diff-8e90c6a1935e803ff09da4cd8515cad18cbbcbc32e54bb2a7a812bb391f832c0R16-R19) [[2]](diffhunk://#diff-cc338dd942540f64a3289b3ed6e2cc9af00fc09ea01b7df2f4eda6ee66602376R12-R15)

**Installer Metadata Improvements:**

* Updated `packaging/beratools.iss` to include version info and product metadata in the installer, improving authenticity and traceability of signed releases.