### PR TITLE
Switch installer release to manual dispatch

### DIFF
--- a/.github/workflows/build-win-installer.yml
+++ b/.github/workflows/build-win-installer.yml
@@ -1,10 +1,12 @@
 name: Build Windows Installer
 
 on:
-  push:
-    tags:
-      - '*.*.*'
   workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "Version tag to release (leave empty for test-signing)"
+        required: false
+        type: string
 
 jobs:
   build:
@@ -24,33 +26,43 @@ jobs:
       - name: Select signing policy
         id: signing
         shell: pwsh
+        env:
+          RELEASE_TAG: ${{ inputs.release_tag }}
         run: |
           $ErrorActionPreference = "Stop"
-          if ($env:GITHUB_EVENT_NAME -eq "workflow_dispatch") {
+          $releaseTag = ([string]$env:RELEASE_TAG).Trim()
+
+          if (-not $releaseTag) {
             "enabled=true" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
             "signing_policy=test-signing" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
             "publish_release=false" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
-            Write-Host "Manual run: building with the test-signing policy."
+            Write-Host "No release tag supplied. Building with the test-signing policy."
             exit 0
           }
 
-          $commitSha = (git rev-parse "$env:GITHUB_SHA^{commit}").Trim()
-          git fetch --no-tags origin main:refs/remotes/origin/main
-          git merge-base --is-ancestor $commitSha origin/main
-          $mergeBaseResult = $LASTEXITCODE
-
-          if ($mergeBaseResult -eq 0) {
-            "enabled=true" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
-            "signing_policy=release-signing" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
-            "publish_release=true" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
-            Write-Host "Tag commit is on main. Building with the release-signing policy."
-          } elseif ($mergeBaseResult -eq 1) {
-            "enabled=false" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
-            "publish_release=false" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
-            Write-Host "Tag commit is not on main. Build and signing steps will be skipped."
-          } else {
-            throw "Unable to determine whether $commitSha is on main."
+          if ($env:GITHUB_REF -ne "refs/heads/main") {
+            throw "Release signing must be dispatched from the main branch."
           }
+          if ($releaseTag -notmatch '^\d+\.\d+\.\d+(?:\.\d+)?$') {
+            throw "Release tag must be a numeric version such as 1.2.3: $releaseTag"
+          }
+
+          git show-ref --verify --quiet "refs/tags/$releaseTag"
+          if ($LASTEXITCODE -ne 0) {
+            throw "Release tag does not exist: $releaseTag"
+          }
+
+          $tagCommit = (git rev-parse "refs/tags/$releaseTag^{commit}").Trim()
+          $workflowCommit = (git rev-parse "$env:GITHUB_SHA^{commit}").Trim()
+          if ($tagCommit -ne $workflowCommit) {
+            throw "Release tag $releaseTag points to $tagCommit, but main was dispatched at $workflowCommit."
+          }
+
+          "enabled=true" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          "signing_policy=release-signing" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          "publish_release=true" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          "release_tag=$releaseTag" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          Write-Host "Tag $releaseTag matches main at $workflowCommit. Building with the release-signing policy."
 
       - name: Setup Go
         if: steps.signing.outputs.enabled == 'true'
@@ -76,6 +88,8 @@ jobs:
       - name: Build installer
         id: build-installer
         if: steps.signing.outputs.enabled == 'true'
+        env:
+          RELEASE_TAG: ${{ steps.signing.outputs.release_tag }}
         run: |
           powershell -ExecutionPolicy Bypass -File packaging/build.ps1
 
@@ -88,7 +102,12 @@ jobs:
             throw "Installer filename does not contain a supported version: $($installers[0].Name)"
           }
 
-          "version=$($Matches[1])" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          $version = $Matches[1]
+          if ($env:RELEASE_TAG -and $version -ne $env:RELEASE_TAG) {
+            throw "Built installer version $version does not match release tag $env:RELEASE_TAG."
+          }
+
+          "version=$version" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
         shell: pwsh
         working-directory: ${{ github.workspace }}
 
@@ -150,7 +169,7 @@ jobs:
         if: steps.signing.outputs.publish_release == 'true'
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ github.ref_name }}
+          tag_name: ${{ steps.signing.outputs.release_tag }}
           files: packaging/dist-signed/beratools-installer-*.exe
           body: |
             Windows installer signed under the [BERA Tools Code signing policy](https://github.com/appliedgrg/beratools/blob/main/CODE_SIGNING_POLICY.md).

--- a/.github/workflows/build-win-installer.yml
+++ b/.github/workflows/build-win-installer.yml
@@ -43,7 +43,8 @@ jobs:
           if ($env:GITHUB_REF -ne "refs/heads/main") {
             throw "Release signing must be dispatched from the main branch."
           }
-          if ($releaseTag -notmatch '^\d+\.\d+\.\d+(?:\.\d+)?$') {
+          $versionPattern = '^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$'
+          if ($releaseTag -notmatch $versionPattern) {
             throw "Release tag must be a numeric version such as 1.2.3: $releaseTag"
           }
 
@@ -56,6 +57,12 @@ jobs:
           $workflowCommit = (git rev-parse "$env:GITHUB_SHA^{commit}").Trim()
           if ($tagCommit -ne $workflowCommit) {
             throw "Release tag $releaseTag points to $tagCommit, but main was dispatched at $workflowCommit."
+          }
+
+          $versionTags = @(git tag --list | Where-Object { $_ -match $versionPattern })
+          $latestTag = $versionTags | Sort-Object { [version]$_ } -Descending | Select-Object -First 1
+          if ($releaseTag -ne $latestTag) {
+            throw "Release tag $releaseTag is not the latest numeric version; expected $latestTag."
           }
 
           "enabled=true" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
@@ -90,6 +97,7 @@ jobs:
         if: steps.signing.outputs.enabled == 'true'
         env:
           RELEASE_TAG: ${{ steps.signing.outputs.release_tag }}
+          APP_VERSION: ${{ steps.signing.outputs.release_tag }}
         run: |
           powershell -ExecutionPolicy Bypass -File packaging/build.ps1
 
@@ -171,6 +179,7 @@ jobs:
         with:
           tag_name: ${{ steps.signing.outputs.release_tag }}
           files: packaging/dist-signed/beratools-installer-*.exe
+          overwrite_files: false
           body: |
             Windows installer signed under the [BERA Tools Code signing policy](https://github.com/appliedgrg/beratools/blob/main/CODE_SIGNING_POLICY.md).
           append_body: true

--- a/CODE_SIGNING_POLICY.md
+++ b/CODE_SIGNING_POLICY.md
@@ -9,9 +9,9 @@ Free code signing is provided by [SignPath.io](https://about.signpath.io/), cert
 
 ## Release process
 
-Official Windows installers are built by GitHub Actions from version tags whose commits are on the `main` branch. SignPath verifies the build origin and requires an authorized approver to approve each `release-signing` request before the installer is published.
+Official Windows installers are built by manually dispatching GitHub Actions from `main` with a version tag that points exactly to the dispatched commit. SignPath verifies the `main` build origin and requires an authorized approver to approve each `release-signing` request before the installer is published.
 
-Manual GitHub Actions runs use the `test-signing` policy, do not require signing approval, and do not use the release certificate. Release signing uses a separate policy that requires an authorized approver.
+Manual GitHub Actions runs without a release tag use the `test-signing` policy, do not require signing approval, and do not use the release certificate. Release signing uses a separate policy that requires an authorized approver.
 
 Maintainers can find test-signing and release instructions in [Publishing BERA Tools](docs/files/developer/publishing.md#windows-installer-signing).
 

--- a/docs/files/developer/maintainer.md
+++ b/docs/files/developer/maintainer.md
@@ -56,9 +56,10 @@ Here is a summary of the actions defined in all workflow files in `.github/workf
     - Builds the package and publishes to TestPyPI.
 
 - __build-win-installer.yml__
-    - Summary: Builds the Windows installer and submits it to SignPath using `test-signing`.
+    - Summary: Builds and signs the Windows installer in test or release mode.
     - Trigger: Manually triggered via `workflow_dispatch` on the selected branch.
-    - Does not require signing approval and uploads unsigned and test-signed Actions artifacts without publishing a GitHub Release.
+    - With no release tag, uses `test-signing` and uploads test-signed Actions artifacts without publishing a GitHub Release.
+    - With a release tag, requires `main`, verifies that the tag points exactly to the dispatched commit, uses `release-signing`, and attaches the approved installer to that GitHub Release.
 
 ### Version tag push
 
@@ -71,11 +72,6 @@ Here is a summary of the actions defined in all workflow files in `.github/workf
     - Summary: Official PyPI publish workflow for tagged releases.
     - Trigger: On version tag push from `main`.
     - Builds the package and publishes to PyPI.
-
-- __build-win-installer.yml__
-    - Summary: Builds the Windows installer and submits it to SignPath using `release-signing`.
-    - Trigger: On a version tag push whose commit is in `main`.
-    - Waits for SignPath approval, verifies the formal signature, and attaches the signed installer to the GitHub Release.
 
 See [Publishing BERA Tools](publishing.md#windows-installer-signing) for the signing and release procedure.
 
@@ -106,16 +102,17 @@ flowchart LR
 
     CheckType -->|Manual trigger| Manual[Workflow Dispatch]
     Manual --> PyPITest[Test PyPI]
-    Manual --> InstallerTest[Windows Installer Test]
+    Manual --> InstallerMode{Release tag supplied?}
+    InstallerMode -->|No| InstallerTest[Windows Installer Test]
     InstallerTest --> TestSign[SignPath test-signing]
     TestSign --> SignedTest[Signed Actions Artifact]
+    InstallerMode -->|Yes, from main| WindowsInstaller[Windows Installer Release]
+    WindowsInstaller --> SignPathApproval[SignPath Approval]
+    SignPathApproval --> SignedRelease[Signed GitHub Release]
     
     CheckType -->|Version tag| Release[Release]
     Release --> Anaconda[Conda]
     Release --> PyPI[PyPI]
-    Release --> WindowsInstaller[Windows Installer]
-    WindowsInstaller --> SignPathApproval[SignPath Approval]
-    SignPathApproval --> SignedRelease[Signed GitHub Release]
     
     classDef push fill:#e1f5ff,stroke:#01579b
     classDef pr fill:#fff3e0,stroke:#e65100
@@ -123,7 +120,7 @@ flowchart LR
     classDef rel fill:#e8f5e9,stroke:#2e7d32
     
     class Mkdocs,Pytest push
-    class PyPITest,InstallerTest,TestSign,SignedTest manual
+    class PyPITest,InstallerMode,InstallerTest,TestSign,SignedTest manual
     class Tox pr
     class Anaconda,PyPI,WindowsInstaller,SignPathApproval,SignedRelease rel
 ```

--- a/docs/files/developer/publishing.md
+++ b/docs/files/developer/publishing.md
@@ -1,6 +1,6 @@
 # Publishing BERA Tools
 
-BERA Tools is published to Conda and PyPI when the `main` branch is tagged with a new version. The same tag builds, signs, and publishes the Windows installer.
+BERA Tools is published to Conda and PyPI when the `main` branch is tagged with a new version. The Windows installer is then built, signed, and published by manually dispatching its release workflow from that tagged `main` commit.
 
 ## Versioning
 
@@ -31,9 +31,8 @@ Official Windows installers follow the project [Code signing policy](https://git
 
 | Trigger | Signing policy | Approval | Result |
 | --- | --- | --- | --- |
-| Manual `workflow_dispatch` | `test-signing` | Disabled by policy | Signed GitHub Actions artifact only |
-| Version tag on a commit in `main` | `release-signing` | One approval required | Signed artifact and GitHub Release |
-| Version tag outside `main` | None | None | Build and signing steps are skipped |
+| Manual dispatch with no release tag | `test-signing` | Disabled by policy | Signed GitHub Actions artifact only |
+| Manual dispatch from `main` with a matching release tag | `release-signing` | One approval required | Signed artifact and GitHub Release |
 
 ### Manual Signing Test
 
@@ -50,12 +49,13 @@ The test certificate is self-signed, so `Get-AuthenticodeSignature` may report `
 ### Production Release
 
 1. Merge the release changes into `main` and ensure all release workflows are ready.
-2. Create a `major.minor.patch` version tag on a commit in `main` and push the tag.
-3. Monitor the [Build Windows Installer](https://github.com/appliedgrg/beratools/actions/workflows/build-win-installer.yml) run.
-4. Open the signing request from the SignPath email or the URL printed by the workflow.
-5. An authorized SignPath approver must approve the request within the workflow's one-hour timeout.
-6. Confirm the release signature status is `Valid`.
-7. Confirm the signed installer was attached to the GitHub Release.
+2. Create a `major.minor.patch` version tag on the current `main` commit and push the tag. Do not advance `main` until all release workflows complete.
+3. Open [Build Windows Installer](https://github.com/appliedgrg/beratools/actions/workflows/build-win-installer.yml), select **Run workflow**, choose `main`, and enter the version tag in **Version tag to release**.
+4. Confirm the workflow verifies that the supplied tag points exactly to the dispatched `main` commit and submits with `release-signing`.
+5. Open the signing request from the SignPath email or the URL printed by the workflow.
+6. An authorized SignPath approver must approve the request within the workflow's one-hour timeout.
+7. Confirm the release signature status is `Valid`.
+8. Confirm the signed installer was attached to the GitHub Release.
 
 The person who creates the tag does not need to be a SignPath approver. With multiple approvers and one required approval, any listed approver can authorize the request. If the request is denied or times out, the workflow does not publish the installer.
 
@@ -73,6 +73,8 @@ Open **Projects -> beratools -> Signing policies** in SignPath to review policy 
 | Result | Actions artifact only | Approved GitHub Release |
 
 For `release-signing`, require trusted-build-system verification and origin verification. Set the repository URL to `https://github.com/appliedgrg/beratools.git`, the allowed branch to `main`, and the allowed build definition to `.github/workflows/build-win-installer.yml`.
+
+GitHub reports a tag-triggered workflow's tag name as its origin branch. Do not add version tags or wildcard patterns to the production policy's allowed branches. Release signing is dispatched from `main`, and the workflow verifies that the supplied tag resolves exactly to that `main` commit.
 
 Both policies use the default artifact configuration below. Only these artifact rules are shared; certificates, approval requirements, branch restrictions, and origin settings remain policy-specific.
 
@@ -96,7 +98,7 @@ The GitHub workflow reads `SIGNPATH_API_TOKEN` and `SIGNPATH_ORGANIZATION_ID` fr
 
 For maintainer handoff, add replacement users as SignPath approvers and retain at least one organization administrator or project configurator. With multiple approvers and one required approval, any listed approver can approve. Require MFA, keep the `CI builds` submitter independent of personal accounts, and verify replacement access before removing a departing maintainer.
 
-After any portal or artifact-configuration change, run the manual signing test. The message `No GitHub policy found at .signpath/policies/...` is informational when no repository policy file is configured; open the signing request in SignPath for actual processing failures.
+After any portal or artifact-configuration change, run the manual signing test. The message `No GitHub policy found at .signpath/policies/...` is informational when no repository policy file is configured; open the signing request in SignPath for actual processing failures. GitHub connector requests contain attestation authorization data and cannot be promoted with SignPath's resubmit API.
 
 ## Releases
 

--- a/docs/files/developer/publishing.md
+++ b/docs/files/developer/publishing.md
@@ -51,13 +51,13 @@ The test certificate is self-signed, so `Get-AuthenticodeSignature` may report `
 1. Merge the release changes into `main` and ensure all release workflows are ready.
 2. Create a `major.minor.patch` version tag on the current `main` commit and push the tag. Do not advance `main` until all release workflows complete.
 3. Open [Build Windows Installer](https://github.com/appliedgrg/beratools/actions/workflows/build-win-installer.yml), select **Run workflow**, choose `main`, and enter the version tag in **Version tag to release**.
-4. Confirm the workflow verifies that the supplied tag points exactly to the dispatched `main` commit and submits with `release-signing`.
+4. Confirm the workflow verifies that the supplied tag points exactly to the dispatched `main` commit, is the latest numeric version tag, and submits with `release-signing`.
 5. Open the signing request from the SignPath email or the URL printed by the workflow.
 6. An authorized SignPath approver must approve the request within the workflow's one-hour timeout.
 7. Confirm the release signature status is `Valid`.
 8. Confirm the signed installer was attached to the GitHub Release.
 
-The person who creates the tag does not need to be a SignPath approver. With multiple approvers and one required approval, any listed approver can authorize the request. If the request is denied or times out, the workflow does not publish the installer.
+The person who creates the tag does not need to be a SignPath approver. With multiple approvers and one required approval, any listed approver can authorize the request. If the request is denied or times out, the workflow does not publish the installer. A rerun does not overwrite an installer asset that is already attached to the release.
 
 ### SignPath Configuration
 

--- a/packaging/build.ps1
+++ b/packaging/build.ps1
@@ -7,14 +7,19 @@ Write-Host "=== Beratools Windows Installer Build ===" -ForegroundColor Cyan
 
 $scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
 
-# Get version from git tag
-$version = (git describe --tags --abbrev=0 2>$null)
-if (-not $version) {
-    $version = "0.0.0"
-    Write-Host "No git tag found, using default version: $version" -ForegroundColor Yellow
+# Use the verified CI release version when provided; local and test builds fall back to Git.
+$version = ([string]$env:APP_VERSION).Trim()
+if ($version) {
+    Write-Host "Version from APP_VERSION: $version" -ForegroundColor Green
 } else {
-    $version = $version.TrimStart('v')
-    Write-Host "Version from git tag: $version" -ForegroundColor Green
+    $version = (git describe --tags --abbrev=0 2>$null)
+    if (-not $version) {
+        $version = "0.0.0"
+        Write-Host "No git tag found, using default version: $version" -ForegroundColor Yellow
+    } else {
+        $version = $version.TrimStart('v')
+        Write-Host "Version from git tag: $version" -ForegroundColor Green
+    }
 }
 $env:APP_VERSION = $version
 


### PR DESCRIPTION
This pull request updates the Windows installer release workflow to require manual dispatch from the `main` branch using an explicit release tag, with improved safety checks and clearer documentation for maintainers. The workflow now distinguishes between test-signing and release-signing based on the presence of a release tag input, and enforces that release tags point exactly to the dispatched commit. Documentation has been revised to reflect this new process and to clarify the steps and policies for both test and production releases.

**Workflow and Release Process Changes**
* The `build-win-installer.yml` workflow now triggers only via manual dispatch (`workflow_dispatch`) and accepts an optional `release_tag` input to distinguish between test and release builds.
* Release signing is only enabled if a valid release tag is supplied, the workflow is dispatched from the `main` branch, and the tag points exactly to the dispatched commit. The workflow enforces version tag format and validates the tag-commit match.
* The workflow ensures that the built installer version matches the supplied release tag, preventing accidental mismatches.
* The GitHub Release is now published using the exact supplied release tag, not the branch or workflow context.

**Documentation Updates**
* All maintainer and publishing documentation has been updated to describe the new manual release process, including required steps, trigger conditions, and updated flowcharts and tables. 
* 
These changes improve release safety and clarity, ensuring that only intentional, verified releases are signed and published.