### PR TITLE
Migrate docs workflow to Zensical builds

### DIFF
--- a/.github/workflows/mkdocs-gh-pages.yml
+++ b/.github/workflows/mkdocs-gh-pages.yml
@@ -11,11 +11,15 @@ on:
       - main
     paths:
       - 'docs/**'
+      - 'pyproject.toml'
+      - '.github/workflows/mkdocs-gh-pages.yml'
   push:
     branches:
       - main
     paths:
       - 'docs/**'
+      - 'pyproject.toml'
+      - '.github/workflows/mkdocs-gh-pages.yml'
 
 jobs:
   test-docs:

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,10 +1,10 @@
-# Markdownlint configuration for MkDocs documentation
+# Markdownlint configuration for Zensical documentation
 
 # Enable all rules by default
 default: true
 
 # MD007: Unordered list indentation
-# MkDocs uses 4 spaces for nested lists
+# The documentation uses 4 spaces for nested lists
 MD007:
   indent: 4
 

--- a/docs/files/developer/documentation.md
+++ b/docs/files/developer/documentation.md
@@ -1,6 +1,6 @@
 # Documentation
 
-BERA Tools uses MkDocs for user/developer/API documentation. MkDocs is a static site generator that's geared towards project documentation. The documentation source files are written in Markdown and are located in the `docs/` folder of the GitHub repository.
+BERA Tools uses [Zensical](https://zensical.org/) for user, developer, and API documentation. The documentation source files are written in Markdown and are located in the `docs/` folder of the GitHub repository. Zensical reads the existing `mkdocs.yml` through its supported compatibility layer; use the `zensical` CLI rather than invoking `mkdocs` directly.
 
 ## Documentation File Structure
 
@@ -11,7 +11,7 @@ docs/
 │   ├── developer_guide.md  # Developer guide
 │   ├── index.md            # Documentation homepage
 │   ├── overview.md         # Project overview
-│   ├── requirements.txt    # Python requirements for mkdocs
+│   ├── requirements.txt    # Python requirements for Zensical
 │   ├── user_guide.md       # User guide
 │   │
 │   ├── css/                # Custom CSS for docs
@@ -19,7 +19,7 @@ docs/
 │   ├── icons/              # Project and documentation icons
 │   ├── screenshots/        # Screenshots for guides and docs
 │   ├── user/               # User-specific documentation
-├── mkdocs.yml              # MkDocs configuration file
+├── mkdocs.yml              # Zensical-compatible configuration file
 ```
 
 ## Contribution Guidelines
@@ -36,40 +36,38 @@ By following these guidelines, you can help ensure that BERA Tools documentation
 
 ## Developing Documentation Locally
 
-To build the documentation locally, you need to have MkDocs and extensions installed in development environment.
+Use the Conda environment `data` to build and preview the documentation locally.
 
-1. Install the required dependencies in development environment using the `docs/requirements.txt` file:
+1. Install the required dependencies from the repository root:
 
-   ```bash
-   pip install -r requirements.txt
+   ```powershell
+   conda run -n data python -m pip install -r docs/files/requirements.txt
    ```
 
-   or use the pyproject.toml in the root directory:
+   Alternatively, install the documentation extra from `pyproject.toml`:
 
-   ```bash
-   pip install .[doc]
+   ```powershell
+   conda run -n data python -m pip install ".[doc]"
    ```
 
-2. Serve the live documentation locally
-   This command starts a local development server that automatically rebuilds the documentation when changes are made . It is useful for previewing changes in real-time.
+2. Serve the documentation locally. This starts a development server that automatically rebuilds when files change:
 
-   ```bash
-   mkdocs serve
+   ```powershell
+   conda run -n data zensical serve -f docs/mkdocs.yml
    ```
 
- Open your browser and navigate to `http://127.0.0.1:8000` to view the documentation.
+   Open `http://127.0.0.1:8000` to preview the site.
 
-1. Build the documentation locally
-This generates the static site files in the `site/` directory. It's optional for local preview (use `mkdocs serve` for a live‑reloading preview).
+3. Build the documentation. This generates the static site in `docs/site/`:
 
-```bash
-mkdocs build
-```
+   ```powershell
+   conda run -n data zensical build -f docs/mkdocs.yml
+   ```
 
 ## Deployment
 
-The documentation is automatically deployed to GitHub Pages using a GitHub Actions workflow defined in `.github/workflows/mkdocs-gh-pages.yml`.
+The documentation is automatically validated and deployed to GitHub Pages using `.github/workflows/mkdocs-gh-pages.yml`.
 
-This workflow triggers on pushes to the `main` branch that affect files in the `docs/` directory. It builds the documentation and publishes it to the `gh-pages` branch, making it available at `https://appliedgrg.github.io/beratools/`.
+Pull requests that change documentation inputs run a Zensical build without deploying. Matching pushes to `main` build `docs/site`, upload it as a GitHub Pages artifact, and deploy it with GitHub's Pages action. The published site is available at `https://appliedgrg.github.io/beratools/`.
 
 ![Doc Deployment Config](../screenshots/gh_pages_config.png)

--- a/docs/files/developer/documentation.md
+++ b/docs/files/developer/documentation.md
@@ -36,32 +36,32 @@ By following these guidelines, you can help ensure that BERA Tools documentation
 
 ## Developing Documentation Locally
 
-Use the Conda environment `data` to build and preview the documentation locally.
+Activate the development environment described in the [local development setup](development.md#local-development-setup), then run these commands from the repository root.
 
 1. Install the required dependencies from the repository root:
 
-   ```powershell
-   conda run -n data python -m pip install -r docs/files/requirements.txt
+   ```console
+   python -m pip install -r docs/files/requirements.txt
    ```
 
    Alternatively, install the documentation extra from `pyproject.toml`:
 
-   ```powershell
-   conda run -n data python -m pip install ".[doc]"
+   ```console
+   python -m pip install ".[doc]"
    ```
 
 2. Serve the documentation locally. This starts a development server that automatically rebuilds when files change:
 
-   ```powershell
-   conda run -n data zensical serve -f docs/mkdocs.yml
+   ```console
+   zensical serve -f docs/mkdocs.yml
    ```
 
    Open `http://127.0.0.1:8000` to preview the site.
 
 3. Build the documentation. This generates the static site in `docs/site/`:
 
-   ```powershell
-   conda run -n data zensical build -f docs/mkdocs.yml
+   ```console
+   zensical build -f docs/mkdocs.yml
    ```
 
 ## Deployment

--- a/docs/files/developer/maintainer.md
+++ b/docs/files/developer/maintainer.md
@@ -32,9 +32,9 @@ Here is a summary of the actions defined in all workflow files in `.github/workf
 ### Push to main
 
 - __mkdocs-gh-pages.yml__
-    - Summary: Documentation deployment workflow that builds and publishes docs on changes to `docs/**`.
-    - Trigger: On push to `main` affecting `docs/**`.
-    - Deploys MkDocs documentation to GitHub Pages.
+    - Summary: Zensical validation and deployment workflow for documentation inputs.
+    - Trigger: On pull requests and pushes to `main` affecting documentation, its dependencies, or the workflow.
+    - Builds with Zensical and deploys the generated artifact to GitHub Pages on pushes.
 
 ### Pull request to main
 
@@ -94,7 +94,7 @@ flowchart LR
     Start([Code Change]) --> CheckType{Push to GitHub}
     
     CheckType -->|Push to main| Files{Files changed}
-    Files -->|docs/**| Mkdocs[Deploy Docs]
+    Files -->|Documentation inputs| Zensical[Deploy Docs]
     Files -->|beratools/**| Pytest[CI Tests]
     
     CheckType -->|PR to main| PR[PR Validation]
@@ -119,7 +119,7 @@ flowchart LR
     classDef manual fill:#f3e5f5,stroke:#6a1b9a
     classDef rel fill:#e8f5e9,stroke:#2e7d32
     
-    class Mkdocs,Pytest push
+    class Zensical,Pytest push
     class PyPITest,InstallerMode,InstallerTest,TestSign,SignedTest manual
     class Tox pr
     class Anaconda,PyPI,WindowsInstaller,SignPathApproval,SignedRelease rel

--- a/docs/files/requirements.txt
+++ b/docs/files/requirements.txt
@@ -1,4 +1,4 @@
-zensical
+zensical==0.0.53
 mkdocstrings
 mkdocstrings-python
 pymdown-extensions

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,3 +1,4 @@
+# Zensical compatibility configuration. Build with `zensical`, not `mkdocs`.
 site_name: BERA Tools Guide
 
 theme:
@@ -108,8 +109,6 @@ nav:
 
 plugins:
   - search
-  - git-revision-date-localized:
-      type: date
   - mkdocstrings:
       handlers:
         python:
@@ -142,5 +141,4 @@ plugins:
             - url: https://shapely.readthedocs.io/en/stable/objects.inv
             - url: https://numpy.org/doc/stable/objects.inv
             - url: https://pandas.pydata.org/pandas-docs/stable/objects.inv
-
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,14 +61,12 @@ test = [
     "pytest-qt",
     "pywinauto; platform_system == 'Windows'",
 ]
+# Zensical consumes docs/mkdocs.yml through its supported compatibility layer.
 doc = [
-    "mkdocs",
-    "mkdocs-material",
+    "zensical==0.0.53",
     "mkdocstrings",
     "mkdocstrings-python",
     "pymdown-extensions",
-    "mkdocs-git-revision-date-localized-plugin",
-    "click==8.2.1",
 ]
 
 [project.scripts]


### PR DESCRIPTION
This pull request migrates the documentation system from MkDocs to Zensical and updates related configuration, documentation, and workflow files to reflect this change. It ensures that all documentation build, preview, and deployment steps now use Zensical, and clarifies instructions for contributors and maintainers. The documentation dependencies are updated and the GitHub Actions workflow is expanded to better track changes relevant to documentation.

**Documentation system migration and workflow updates:**

* Migrated the documentation system from MkDocs to Zensical, updating all references in documentation files and configuration to use the `zensical` CLI and specifying the compatible version (`zensical==0.0.53`). 

* Updated the GitHub Actions workflow `.github/workflows/mkdocs-gh-pages.yml` to trigger on changes to `pyproject.toml` and the workflow file itself, in addition to documentation sources, ensuring deployments stay in sync with all relevant files.
* Revised deployment and validation instructions in both user and maintainer documentation to describe the Zensical-based process, including local development, build, and deployment steps, and updated workflow diagrams and summaries accordingly. 

**Configuration and dependency cleanup:**

* Removed MkDocs-specific dependencies and plugins from `pyproject.toml` and `docs/mkdocs.yml`, ensuring compatibility with Zensical and eliminating unused plugins.

* Updated comments and configuration in `.markdownlint.yml` for clarity and to match the new documentation system branding.