### PR TITLE
Fix/conda publish

### DIFF
--- a/.github/workflows/publish_to_anaconda.yml
+++ b/.github/workflows/publish_to_anaconda.yml
@@ -152,7 +152,6 @@ jobs:
           condarc: |
             channel_priority: strict
             channels:
-              - appliedgrg
               - conda-forge
           cache-environment: false
 
@@ -171,7 +170,7 @@ jobs:
 
           echo "📦 Installing built package artifact(s):"
           printf '  %s\n' "${files[@]}"
-          micromamba install -n bera-conda-smoke -y -c appliedgrg -c conda-forge "${files[@]}"
+          micromamba install -n bera-conda-smoke -y -c conda-forge "${files[@]}"
 
           echo "🔎 Smoke testing installed package"
           micromamba run -n bera-conda-smoke python -c "import beratools; print(beratools.__version__)"
@@ -206,12 +205,12 @@ jobs:
           echo "🎉 Upload complete!"
 
       - name: Upload dry-run Conda package
-        if: steps.tag_guard.outputs.publish == 'false'
+        if: always() && steps.tag_guard.outputs.publish == 'false'
         uses: actions/upload-artifact@v7
         with:
           name: beratools-conda-${{ steps.tag_guard.outputs.release_tag }}
           path: dist/conda/*
-          if-no-files-found: error
+          if-no-files-found: warn
 
       - name: Zip test data files
         if: steps.tag_guard.outputs.publish == 'true'

--- a/.github/workflows/publish_to_anaconda.yml
+++ b/.github/workflows/publish_to_anaconda.yml
@@ -8,6 +8,16 @@ on:
     tags:
         - '*.*.*' # Trigger when a tagged with format like 1.0.0
   workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "Version tag to publish"
+        required: true
+        type: string
+      dry_run:
+        description: "Build and validate without publishing"
+        required: true
+        default: true
+        type: boolean
 
 jobs:
   build-publish:
@@ -22,21 +32,48 @@ jobs:
         uses: actions/checkout@v6
         with:
           token: ${{ github.token }}
-          persist-credentials: true
+          persist-credentials: false
+          fetch-depth: 0
 
-      - name: Check if tagged commit is on main
+      - name: Validate release tag
         id: tag_guard
+        env:
+          INPUT_RELEASE_TAG: ${{ inputs.release_tag }}
+          INPUT_DRY_RUN: ${{ inputs.dry_run }}
         run: |
           set -euo pipefail
-          commit_sha="${GITHUB_SHA:-$(git rev-parse HEAD)}"
-          git fetch origin main
-          if git branch -r --contains "$commit_sha" | grep -q 'origin/main'; then
-            echo "on_main=true" >> "$GITHUB_OUTPUT"
-            echo "✅ Tag commit is on main. Proceeding with publish steps."
+          if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
+            release_tag="$INPUT_RELEASE_TAG"
           else
-            echo "on_main=false" >> "$GITHUB_OUTPUT"
-            echo "⏭️ Tag commit is not on main. All publish steps will be skipped."
+            release_tag="$GITHUB_REF_NAME"
           fi
+
+          if [[ ! "$release_tag" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+            echo "Release tag must be a numeric version such as 1.2.3: $release_tag" >&2
+            exit 1
+          fi
+
+          git fetch origin main --tags
+          if ! commit_sha="$(git rev-parse "refs/tags/$release_tag^{commit}")"; then
+            echo "Release tag does not exist: $release_tag" >&2
+            exit 1
+          fi
+
+          if ! git merge-base --is-ancestor "$commit_sha" origin/main; then
+            echo "Release tag $release_tag is not on main." >&2
+            exit 1
+          fi
+
+          git checkout --detach "$commit_sha"
+          echo "on_main=true" >> "$GITHUB_OUTPUT"
+          echo "release_tag=$release_tag" >> "$GITHUB_OUTPUT"
+          if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" && "$INPUT_DRY_RUN" == "true" ]]; then
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+            echo "Dry run enabled; publishing steps will be skipped."
+          else
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+          fi
+          echo "Release tag $release_tag points to a commit on main."
 
       - name: Set up Python ${{ matrix.python-version }}
         if: steps.tag_guard.outputs.on_main == 'true'
@@ -60,16 +97,16 @@ jobs:
       - name: Set VERSION from tag
         if: steps.tag_guard.outputs.on_main == 'true'
         run: |
-          echo "VERSION=${GITHUB_REF_NAME}" >> $GITHUB_ENV
-          echo "GIT_TAG=${GITHUB_REF_NAME}" >> $GITHUB_ENV
+          echo "VERSION=${{ steps.tag_guard.outputs.release_tag }}" >> "$GITHUB_ENV"
+          echo "GIT_TAG=${{ steps.tag_guard.outputs.release_tag }}" >> "$GITHUB_ENV"
 
       # IMPORTANT: run build inside ./packaging and pass channels explicitly
       - name: Build Conda package (from ./packaging, with channels)
         if: steps.tag_guard.outputs.on_main == 'true'
         working-directory: packaging
         env:
-          VERSION: ${{ github.ref_name }}
-          GIT_TAG: ${{ github.ref_name }}
+          VERSION: ${{ steps.tag_guard.outputs.release_tag }}
+          GIT_TAG: ${{ steps.tag_guard.outputs.release_tag }}
         run: |
           set -euo pipefail
           echo "🏗️ Building version: $VERSION (tag: $GIT_TAG)"
@@ -146,7 +183,7 @@ jobs:
           micromamba run -n bera-conda-smoke pytest tests/test_workflow.py --maxfail=1 -q
 
       - name: Upload to Anaconda.org (binstar)
-        if: steps.tag_guard.outputs.on_main == 'true'
+        if: steps.tag_guard.outputs.publish == 'true'
         env:
           ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_API_TOKEN }}
         run: |
@@ -168,17 +205,25 @@ jobs:
 
           echo "🎉 Upload complete!"
 
+      - name: Upload dry-run Conda package
+        if: steps.tag_guard.outputs.publish == 'false'
+        uses: actions/upload-artifact@v7
+        with:
+          name: beratools-conda-${{ steps.tag_guard.outputs.release_tag }}
+          path: dist/conda/*
+          if-no-files-found: error
+
       - name: Zip test data files
-        if: steps.tag_guard.outputs.on_main == 'true'
+        if: steps.tag_guard.outputs.publish == 'true'
         run: |
           zip -j test_data.zip examples/data/CHM.tif examples/data/seed_lines.gpkg
 
       - name: Create or update GitHub Release and upload test data
-        if: steps.tag_guard.outputs.on_main == 'true'
+        if: steps.tag_guard.outputs.publish == 'true'
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ github.ref_name }}
-          name: Release ${{ github.ref_name }}
+          tag_name: ${{ steps.tag_guard.outputs.release_tag }}
+          name: Release ${{ steps.tag_guard.outputs.release_tag }}
           generate_release_notes: true 
           files: test_data.zip
         env:

--- a/.github/workflows/publish_to_anaconda.yml
+++ b/.github/workflows/publish_to_anaconda.yml
@@ -145,15 +145,10 @@ jobs:
         if: steps.tag_guard.outputs.on_main == 'true'
         uses: mamba-org/setup-micromamba@v2
         with:
-          environment-name: bera-conda-smoke
-          create-args: >-
-            python=3.12
-            pytest
           condarc: |
             channel_priority: strict
             channels:
               - conda-forge
-          cache-environment: false
 
       - name: Validate built conda package
         if: steps.tag_guard.outputs.on_main == 'true'
@@ -170,7 +165,8 @@ jobs:
 
           echo "📦 Installing built package artifact(s):"
           printf '  %s\n' "${files[@]}"
-          micromamba install -n bera-conda-smoke -y -c conda-forge "${files[@]}"
+          micromamba create -n bera-conda-smoke -y -c conda-forge \
+            python=3.12 pytest "${files[@]}"
 
           echo "🔎 Smoke testing installed package"
           micromamba run -n bera-conda-smoke python -c "import beratools; print(beratools.__version__)"

--- a/.github/workflows/publish_to_anaconda.yml
+++ b/.github/workflows/publish_to_anaconda.yml
@@ -165,8 +165,11 @@ jobs:
 
           echo "📦 Installing built package artifact(s):"
           printf '  %s\n' "${files[@]}"
-          micromamba create -n bera-conda-smoke -y -c conda-forge \
-            python=3.12 pytest "${files[@]}"
+          local_channel="$RUNNER_TEMP/beratools-channel"
+          rattler-build publish "${files[0]}" --to "file://$local_channel"
+          micromamba create -n bera-conda-smoke -y \
+            -c "file://$local_channel" -c conda-forge \
+            python=3.12 pytest "beratools=$VERSION"
 
           echo "🔎 Smoke testing installed package"
           micromamba run -n bera-conda-smoke python -c "import beratools; print(beratools.__version__)"

--- a/.github/workflows/publish_to_anaconda.yml
+++ b/.github/workflows/publish_to_anaconda.yml
@@ -1,23 +1,21 @@
 name: Publish to Anaconda (rattler-build + Pixi)
 
+run-name: Anaconda ${{ inputs.release_tag || 'dry run' }} from ${{ github.ref_name }}
+
 permissions:
   contents: write
 
 on:
-  push:
-    tags:
-        - '*.*.*' # Trigger when a tagged with format like 1.0.0
   workflow_dispatch:
     inputs:
       release_tag:
-        description: "Version tag to publish"
-        required: true
+        description: "Version tag to publish (leave empty for dry run)"
+        required: false
         type: string
-      dry_run:
-        description: "Build and validate without publishing"
-        required: true
-        default: true
-        type: boolean
+
+concurrency:
+  group: anaconda-${{ inputs.release_tag || github.ref }}
+  cancel-in-progress: false
 
 jobs:
   build-publish:
@@ -39,84 +37,112 @@ jobs:
         id: tag_guard
         env:
           INPUT_RELEASE_TAG: ${{ inputs.release_tag }}
-          INPUT_DRY_RUN: ${{ inputs.dry_run }}
         run: |
           set -euo pipefail
-          if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
-            release_tag="$INPUT_RELEASE_TAG"
-          else
-            release_tag="$GITHUB_REF_NAME"
-          fi
-
-          if [[ ! "$release_tag" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
-            echo "Release tag must be a numeric version such as 1.2.3: $release_tag" >&2
-            exit 1
-          fi
-
+          release_tag="$INPUT_RELEASE_TAG"
+          publish=false
+          reason="No release tag supplied."
           git fetch origin main --tags
-          if ! commit_sha="$(git rev-parse "refs/tags/$release_tag^{commit}")"; then
-            echo "Release tag does not exist: $release_tag" >&2
-            exit 1
+
+          if [[ -n "$release_tag" ]]; then
+            if [[ ! "$release_tag" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+              echo "Release tag must be a numeric version such as 1.2.3: $release_tag" >&2
+              exit 1
+            fi
+
+            if ! tag_commit="$(git rev-parse "refs/tags/$release_tag^{commit}")"; then
+              echo "Release tag does not exist: $release_tag" >&2
+              exit 1
+            fi
+
+            latest_tag="$(git tag --list | grep -E '^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$' | sort -V | tail -n 1)"
+            workflow_commit="$(git rev-parse "$GITHUB_SHA^{commit}")"
+
+            if [[ "$GITHUB_REF" != "refs/heads/main" ]]; then
+              reason="Publishing requires a workflow dispatched from main."
+            elif [[ "$tag_commit" != "$workflow_commit" ]]; then
+              reason="Tag $release_tag does not point to the selected main commit."
+            elif [[ "$release_tag" != "$latest_tag" ]]; then
+              reason="Tag $release_tag is not the latest numeric tag ($latest_tag)."
+            else
+              publish=true
+              reason="Tag $release_tag exactly matches the current main commit and is latest."
+              git checkout --detach "$tag_commit"
+            fi
           fi
 
-          if ! git merge-base --is-ancestor "$commit_sha" origin/main; then
-            echo "Release tag $release_tag is not on main." >&2
-            exit 1
-          fi
-
-          git checkout --detach "$commit_sha"
-          echo "on_main=true" >> "$GITHUB_OUTPUT"
           echo "release_tag=$release_tag" >> "$GITHUB_OUTPUT"
-          if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" && "$INPUT_DRY_RUN" == "true" ]]; then
-            echo "publish=false" >> "$GITHUB_OUTPUT"
-            echo "Dry run enabled; publishing steps will be skipped."
+          echo "publish=$publish" >> "$GITHUB_OUTPUT"
+          echo "reason=$reason" >> "$GITHUB_OUTPUT"
+
+          if [[ "$publish" == "true" ]]; then
+            echo "$reason"
           else
-            echo "publish=true" >> "$GITHUB_OUTPUT"
+            echo "::warning title=Anaconda dry run::$reason Continuing without publishing."
           fi
-          echo "Release tag $release_tag points to a commit on main."
+
+          {
+            echo "### Anaconda workflow mode"
+            echo "- Selected ref: \`$GITHUB_REF\`"
+            echo "- Release tag: \`${release_tag:-none}\`"
+            echo "- Publish: \`$publish\`"
+            echo "- Reason: $reason"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Set up Python ${{ matrix.python-version }}
-        if: steps.tag_guard.outputs.on_main == 'true'
         uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
-      # Disable Pixi cache to avoids pixi.lock lookup
+      # Disable Pixi cache to avoid pixi.lock lookup
       - name: Setup Pixi
-        if: steps.tag_guard.outputs.on_main == 'true'
         uses: prefix-dev/setup-pixi@v0.8.1
         with:
           cache: false
 
       - name: Install rattler-build + anaconda-client
-        if: steps.tag_guard.outputs.on_main == 'true'
         run: |
           pixi global install rattler-build anaconda-client
           echo "$HOME/.pixi/bin" >> "$GITHUB_PATH"
 
-      - name: Set VERSION from tag
-        if: steps.tag_guard.outputs.on_main == 'true'
+      - name: Set package version
+        id: package
+        env:
+          PUBLISH: ${{ steps.tag_guard.outputs.publish }}
+          RELEASE_TAG: ${{ steps.tag_guard.outputs.release_tag }}
         run: |
-          echo "VERSION=${{ steps.tag_guard.outputs.release_tag }}" >> "$GITHUB_ENV"
-          echo "GIT_TAG=${{ steps.tag_guard.outputs.release_tag }}" >> "$GITHUB_ENV"
+          set -euo pipefail
+          if [[ "$PUBLISH" == "true" ]]; then
+            version="$RELEASE_TAG"
+          else
+            version="$(pixi run python -c "from setuptools_scm import get_version; print(get_version(root='.'))")"
+          fi
+
+          if [[ ! "$version" =~ ^[0-9][0-9A-Za-z.+_-]*$ ]]; then
+            echo "Unsupported package version: $version" >&2
+            exit 1
+          fi
+
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "VERSION=$version" >> "$GITHUB_ENV"
+          echo "SETUPTOOLS_SCM_PRETEND_VERSION=$version" >> "$GITHUB_ENV"
+          echo "Package version: $version"
 
       # IMPORTANT: run build inside ./packaging and pass channels explicitly
       - name: Build Conda package (from ./packaging, with channels)
-        if: steps.tag_guard.outputs.on_main == 'true'
         working-directory: packaging
         env:
-          VERSION: ${{ steps.tag_guard.outputs.release_tag }}
-          GIT_TAG: ${{ steps.tag_guard.outputs.release_tag }}
+          VERSION: ${{ steps.package.outputs.version }}
+          SETUPTOOLS_SCM_PRETEND_VERSION: ${{ steps.package.outputs.version }}
         run: |
           set -euo pipefail
-          echo "🏗️ Building version: $VERSION (tag: $GIT_TAG)"
+          echo "🏗️ Building version: $VERSION"
           echo "📌 Using channels: appliedgrg, conda-forge"
           rattler-build build -c appliedgrg -c conda-forge
           echo "Build complete. Outputs under ./output"
 
       # Collect artifacts from a certain place into ./dist/conda
       - name: Collect artifacts to ./dist/conda
-        if: steps.tag_guard.outputs.on_main == 'true'
         run: |
           set -euo pipefail
           mkdir -p dist/conda
@@ -129,20 +155,17 @@ jobs:
             files=($(find packaging -type f \( -name '*.conda' -o -name '*.tar.bz2' \)))
           fi
 
-          if [ ${#files[@]} -eq 0 ]; then
-            echo "❌ No build artifacts found. Check rattler-build output."
+          if [ ${#files[@]} -ne 1 ]; then
+            echo "❌ Expected one build artifact, found ${#files[@]}."
             exit 1
           fi
 
-          for f in "${files[@]}"; do
-            cp -v "$f" dist/conda/
-          done
+          cp -v "${files[0]}" dist/conda/
 
           echo "✅ Artifacts staged in dist/conda:"
           ls -lah dist/conda
 
       - name: Set up conda smoke-test environment
-        if: steps.tag_guard.outputs.on_main == 'true'
         uses: mamba-org/setup-micromamba@v2
         with:
           condarc: |
@@ -151,15 +174,14 @@ jobs:
               - conda-forge
 
       - name: Validate built conda package
-        if: steps.tag_guard.outputs.on_main == 'true'
         shell: bash -el {0}
         run: |
           set -euo pipefail
           shopt -s nullglob
 
           files=(dist/conda/*.conda dist/conda/*.tar.bz2)
-          if [ ${#files[@]} -eq 0 ]; then
-            echo "❌ No package artifacts found to validate."
+          if [ ${#files[@]} -ne 1 ]; then
+            echo "❌ Expected one package artifact to validate, found ${#files[@]}."
             exit 1
           fi
 
@@ -172,7 +194,12 @@ jobs:
             python=3.12 pytest "beratools=$VERSION"
 
           echo "🔎 Smoke testing installed package"
-          micromamba run -n bera-conda-smoke python -c "import beratools; print(beratools.__version__)"
+          installed_version="$(micromamba run -n bera-conda-smoke python -c "from importlib.metadata import version; print(version('BERATools'))")"
+          if [[ "$installed_version" != "$VERSION" ]]; then
+            echo "Installed version $installed_version does not match expected version $VERSION." >&2
+            exit 1
+          fi
+          echo "Installed BERA Tools $installed_version"
           micromamba run -n bera-conda-smoke python -c "from osgeo import gdal; print(gdal.VersionInfo('--version'))"
           micromamba run -n bera-conda-smoke bt --help
           micromamba run -n bera-conda-smoke beratools --help
@@ -189,17 +216,15 @@ jobs:
           shopt -s nullglob
           files=(dist/conda/*.conda dist/conda/*.tar.bz2)
 
-          if [ ${#files[@]} -eq 0 ]; then
-            echo "❌ No package artifacts found to upload."
+          if [ ${#files[@]} -ne 1 ]; then
+            echo "❌ Expected one package artifact to upload, found ${#files[@]}."
             exit 1
           fi
 
-          for f in "${files[@]}"; do
-            echo "🚀 Uploading $f"
-            # Pixi exposes `binstar` (not `anaconda`). Use --label (not --channel).
-            binstar -t "$ANACONDA_API_TOKEN" upload "$f" \
-              --user appliedgrg --label main
-          done
+          echo "🚀 Uploading ${files[0]}"
+          # Pixi exposes `binstar` (not `anaconda`). Use --label (not --channel).
+          binstar -t "$ANACONDA_API_TOKEN" upload --fail "${files[0]}" \
+            --user appliedgrg --label main
 
           echo "🎉 Upload complete!"
 
@@ -207,7 +232,7 @@ jobs:
         if: always() && steps.tag_guard.outputs.publish == 'false'
         uses: actions/upload-artifact@v7
         with:
-          name: beratools-conda-${{ steps.tag_guard.outputs.release_tag }}
+          name: beratools-conda-${{ steps.package.outputs.version }}
           path: dist/conda/*
           if-no-files-found: warn
 
@@ -224,5 +249,6 @@ jobs:
           name: Release ${{ steps.tag_guard.outputs.release_tag }}
           generate_release_notes: true 
           files: test_data.zip
+          overwrite_files: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/beratools/__init__.py
+++ b/beratools/__init__.py
@@ -1,6 +1,6 @@
 __author__ = """Applied Geospatial Research Group"""
 __email__ = 'appliedgrg@gmail.com'
-__version__ = '0.4.0'
+__version__ = '0.5.0'
 __license__ = "GPL-3.0-or-later"
 __copyright__ = "Copyright (c) AppliedGRG"
 __status__ = "Pre-Alpha"

--- a/beratools/__init__.py
+++ b/beratools/__init__.py
@@ -1,6 +1,6 @@
 __author__ = """Applied Geospatial Research Group"""
 __email__ = 'appliedgrg@gmail.com'
-__version__ = '0.5.0'
+__version__ = '0.5.1'
 __license__ = "GPL-3.0-or-later"
 __copyright__ = "Copyright (c) AppliedGRG"
 __status__ = "Pre-Alpha"

--- a/docs/files/developer/maintainer.md
+++ b/docs/files/developer/maintainer.md
@@ -56,12 +56,13 @@ Here is a summary of the actions defined in all workflow files in `.github/workf
     - With no release tag, uses `test-signing` and uploads test-signed Actions artifacts without publishing a GitHub Release.
     - With a release tag, requires `main`, verifies that the tag points exactly to the dispatched commit, uses `release-signing`, and attaches the approved installer to that GitHub Release.
 
-### Version tag push
-
 - __publish_to_anaconda.yml__
-    - Summary: Conda packaging and release workflow that publishes packages and attaches test data to Releases.
-    - Trigger: On version tag push from `main`.
-    - Uses Pixi and rattler-build to build Conda packages, collects build artifacts, uploads them to Anaconda.org, and zips test data to attach to a GitHub Release.
+    - Summary: Builds and smoke-tests Conda packages, publishes eligible releases to Anaconda.org, and attaches test data to GitHub Releases.
+    - Trigger: Manually triggered via `workflow_dispatch` on the selected branch; pushing a version tag does not start this workflow.
+    - With no release tag, runs a non-publishing build and smoke test and uploads the Conda package as an Actions artifact.
+    - With a release tag, publishes only from `main` when the latest numeric tag points exactly to the dispatched commit.
+
+### Version tag push
 
 - __publish_to_pypi.yml__
     - Summary: Official PyPI publish workflow for tagged releases.

--- a/docs/files/developer/publishing.md
+++ b/docs/files/developer/publishing.md
@@ -30,6 +30,12 @@ If `publish_to_pypi.yml` fails before PyPI accepts any distribution files, a mai
 
 Before rerunning, confirm that the version has no files on PyPI. If PyPI accepted any files before the failure, do not rerun blindly: distribution filenames are immutable and duplicate uploads fail. Inspect the release and publish a new patch version if the release is incomplete. A rerun also uses the workflow definition from the tagged commit, so a defect in the workflow itself must be fixed before creating a new release tag.
 
+### Re-running a Failed Anaconda Publication
+
+If the tag-triggered Anaconda workflow fails before uploading a package, open [Publish to Anaconda](https://github.com/appliedgrg/beratools/actions/workflows/publish_to_anaconda.yml), select **Run workflow**, choose `main`, and enter the existing numeric version tag in **Version tag to publish**. The workflow checks out that tag and verifies that its commit belongs to `main` before rebuilding.
+
+Leave **Build and validate without publishing** enabled to test the complete build and smoke-test path without using the Anaconda token or modifying a GitHub Release. The validated Conda package is attached to the workflow run as an artifact. For a production recovery, confirm that the version is absent from [Anaconda BERA Tools](https://anaconda.org/appliedgrg/beratools), disable the dry run, and dispatch the workflow. Do not rerun it after a package file has already been accepted.
+
 ## Windows Installer Signing
 
 Official Windows installers follow the project [Code signing policy](https://github.com/appliedgrg/beratools/blob/main/CODE_SIGNING_POLICY.md). Test and release signing use the same SignPath artifact configuration so a manual test validates the artifact that will later be released.

--- a/docs/files/developer/publishing.md
+++ b/docs/files/developer/publishing.md
@@ -1,6 +1,6 @@
 # Publishing BERA Tools
 
-BERA Tools is published to Conda and PyPI when the `main` branch is tagged with a new version. The Windows installer is then built, signed, and published by manually dispatching its release workflow from that tagged `main` commit.
+BERA Tools is published to PyPI when the `main` branch is tagged with a new version. Conda and Windows installer publishing are manually dispatched from the tagged `main` commit.
 
 ## Versioning
 
@@ -14,7 +14,7 @@ BERA Tools Versioning follows [PEP440](https://peps.python.org/pep-0440/): `majo
 
 ## Packaging BERA Tools
 
-BERA Tools is packaged for distribution on both PyPI and Anaconda. The packaging process is automated using GitHub Actions workflows that are triggered on version tag pushes to the main branch.
+BERA Tools is packaged for distribution on both PyPI and Anaconda. PyPI publishing is triggered by a version tag push; Anaconda publishing requires an explicit manual run from the tagged `main` commit.
 
 See the following workflows:
 
@@ -30,11 +30,13 @@ If `publish_to_pypi.yml` fails before PyPI accepts any distribution files, a mai
 
 Before rerunning, confirm that the version has no files on PyPI. If PyPI accepted any files before the failure, do not rerun blindly: distribution filenames are immutable and duplicate uploads fail. Inspect the release and publish a new patch version if the release is incomplete. A rerun also uses the workflow definition from the tagged commit, so a defect in the workflow itself must be fixed before creating a new release tag.
 
-### Re-running a Failed Anaconda Publication
+### Anaconda Publication
 
-If the tag-triggered Anaconda workflow fails before uploading a package, open [Publish to Anaconda](https://github.com/appliedgrg/beratools/actions/workflows/publish_to_anaconda.yml), select **Run workflow**, choose `main`, and enter the existing numeric version tag in **Version tag to publish**. The workflow checks out that tag and verifies that its commit belongs to `main` before rebuilding.
+Open [Publish to Anaconda](https://github.com/appliedgrg/beratools/actions/workflows/publish_to_anaconda.yml) and select **Run workflow**. Leaving **Version tag to publish** empty runs a non-publishing build and smoke test of the selected branch. The resulting Conda package is attached to the workflow run as an artifact, including when smoke validation fails.
 
-Leave **Build and validate without publishing** enabled to test the complete build and smoke-test path without using the Anaconda token or modifying a GitHub Release. The built Conda package is attached to the workflow run as an artifact, including when smoke validation fails. For a production recovery, confirm that the version is absent from [Anaconda BERA Tools](https://anaconda.org/appliedgrg/beratools), disable the dry run, and dispatch the workflow. Do not rerun it after a package file has already been accepted.
+To publish, choose `main` and enter the latest numeric version tag. Publishing proceeds only when that tag points exactly to the selected `main` commit. A valid tag supplied from another branch, a tag that does not match the selected commit, or an older tag automatically becomes a dry run; a malformed or nonexistent tag fails validation. Confirm that the version is absent from [Anaconda BERA Tools](https://anaconda.org/appliedgrg/beratools) before publishing because existing package files are never overwritten.
+
+If `main` advances after a failed publication, fix the release issue and create a new version tag on the updated commit. The workflow will not publish an older tag from a newer `main` commit.
 
 ## Windows Installer Signing
 

--- a/docs/files/developer/publishing.md
+++ b/docs/files/developer/publishing.md
@@ -34,7 +34,7 @@ Before rerunning, confirm that the version has no files on PyPI. If PyPI accepte
 
 If the tag-triggered Anaconda workflow fails before uploading a package, open [Publish to Anaconda](https://github.com/appliedgrg/beratools/actions/workflows/publish_to_anaconda.yml), select **Run workflow**, choose `main`, and enter the existing numeric version tag in **Version tag to publish**. The workflow checks out that tag and verifies that its commit belongs to `main` before rebuilding.
 
-Leave **Build and validate without publishing** enabled to test the complete build and smoke-test path without using the Anaconda token or modifying a GitHub Release. The validated Conda package is attached to the workflow run as an artifact. For a production recovery, confirm that the version is absent from [Anaconda BERA Tools](https://anaconda.org/appliedgrg/beratools), disable the dry run, and dispatch the workflow. Do not rerun it after a package file has already been accepted.
+Leave **Build and validate without publishing** enabled to test the complete build and smoke-test path without using the Anaconda token or modifying a GitHub Release. The built Conda package is attached to the workflow run as an artifact, including when smoke validation fails. For a production recovery, confirm that the version is absent from [Anaconda BERA Tools](https://anaconda.org/appliedgrg/beratools), disable the dry run, and dispatch the workflow. Do not rerun it after a package file has already been accepted.
 
 ## Windows Installer Signing
 

--- a/docs/files/developer/publishing.md
+++ b/docs/files/developer/publishing.md
@@ -34,7 +34,15 @@ Before rerunning, confirm that the version has no files on PyPI. If PyPI accepte
 
 Open [Publish to Anaconda](https://github.com/appliedgrg/beratools/actions/workflows/publish_to_anaconda.yml) and select **Run workflow**. Leaving **Version tag to publish** empty runs a non-publishing build and smoke test of the selected branch. The resulting Conda package is attached to the workflow run as an artifact, including when smoke validation fails.
 
-To publish, choose `main` and enter the latest numeric version tag. Publishing proceeds only when that tag points exactly to the selected `main` commit. A valid tag supplied from another branch, a tag that does not match the selected commit, or an older tag automatically becomes a dry run; a malformed or nonexistent tag fails validation. Confirm that the version is absent from [Anaconda BERA Tools](https://anaconda.org/appliedgrg/beratools) before publishing because existing package files are never overwritten.
+For an Anaconda release:
+
+1. Merge the release changes into `main`.
+2. Optionally dispatch the workflow from `main` without a version tag for a final dry run.
+3. Create and push the new `major.minor.patch` tag on that exact `main` commit.
+4. Dispatch the workflow from `main` again and enter the new tag in **Version tag to publish**.
+5. Confirm the build and smoke test pass and the package appears on [Anaconda BERA Tools](https://anaconda.org/appliedgrg/beratools).
+
+Pushing the tag does not trigger Anaconda publishing. Publishing proceeds only when the manually supplied tag is the latest numeric version tag and points exactly to the selected `main` commit. A valid tag supplied from another branch, a tag that does not match the selected commit, or an older tag automatically becomes a dry run; a malformed or nonexistent tag fails validation. Confirm that the version is absent from Anaconda before publishing because existing package files are never overwritten.
 
 If `main` advances after a failed publication, fix the release issue and create a new version tag on the updated commit. The workflow will not publish an older tag from a newer `main` commit.
 

--- a/packaging/recipe.yaml
+++ b/packaging/recipe.yaml
@@ -9,8 +9,8 @@ package:
   version: ${{ version }}
 
 source:
-  git: https://github.com/appliedgrg/beratools.git
-  tag: ${{ env.get("GIT_TAG") }}
+  path: ..
+  use_gitignore: true
 
 build:
   number: 0

--- a/packaging/recipe.yaml
+++ b/packaging/recipe.yaml
@@ -15,7 +15,7 @@ source:
 build:
   number: 0
   noarch: python
-  script: python -m pip install . -vv --no-deps
+  script: SETUPTOOLS_SCM_PRETEND_VERSION=${{ version }} python -m pip install . -vv --no-deps
   python:
     entry_points:
       - bt = beratools.cli.entry:run


### PR DESCRIPTION
This pull request updates the Anaconda publishing workflow for BERA Tools to require explicit manual dispatch for all Conda builds and releases, with improved validation and clearer separation between dry runs and official releases. The workflow now ensures only the latest version tag on the main branch is eligible for publishing, and dry runs are always available for testing. Documentation is updated to reflect these changes, and the Conda recipe and package version are incremented.

The most important changes are:

**Workflow and Release Process Improvements:**

* The `.github/workflows/publish_to_anaconda.yml` workflow now only runs on manual dispatch (`workflow_dispatch`), not on tag pushes, and requires explicit input of a release tag for publishing. It validates that the supplied tag is the latest numeric version, exists, and points to the selected `main` commit; otherwise, it performs a dry run. Dry runs always build, test, and upload the Conda package as an artifact, but do not publish. 

* The workflow now enforces that only one build artifact is produced and validated, improving reliability and error reporting. 

**Documentation Updates:**

* The publishing documentation (`docs/files/developer/publishing.md`) is updated to clarify that PyPI releases are triggered by tag pushes, but Anaconda releases require manual workflow dispatch from the tagged `main` commit. Detailed instructions for both dry runs and releases are provided, and the workflow summary in `maintainer.md` is updated to match.

**Packaging and Versioning:**

* The Conda recipe (`packaging/recipe.yaml`) is simplified to build directly from the source tree and always sets `SETUPTOOLS_SCM_PRETEND_VERSION` for correct versioning in both dry runs and releases.

* The package version in `beratools/__init__.py` is incremented to `0.5.1`.