### PR TITLE
Update build.ps1

### DIFF
--- a/beratools/__init__.py
+++ b/beratools/__init__.py
@@ -1,6 +1,6 @@
 __author__ = """Applied Geospatial Research Group"""
 __email__ = 'appliedgrg@gmail.com'
-__version__ = '0.5.1'
+__version__ = '0.5.2'
 __license__ = "GPL-3.0-or-later"
 __copyright__ = "Copyright (c) AppliedGRG"
 __status__ = "Pre-Alpha"

--- a/packaging/build.ps1
+++ b/packaging/build.ps1
@@ -90,8 +90,8 @@ import site
     Write-Host "Configured Python path with beratools parent directory" -ForegroundColor Green
 }
 
-# Step 4: Install pip
-Write-Host "`n[4/9] Installing pip..." -ForegroundColor Yellow
+# Step 4: Install pip and Python build tools
+Write-Host "`n[4/9] Installing pip and Python build tools..." -ForegroundColor Yellow
 
 if (-not (Test-Path (Join-Path $buildDir "python\Scripts\pip.exe"))) {
     Invoke-WebRequest -Uri "https://bootstrap.pypa.io/get-pip.py" -OutFile "get-pip.py" -Verbose
@@ -101,6 +101,14 @@ if (-not (Test-Path (Join-Path $buildDir "python\Scripts\pip.exe"))) {
 } else {
     Write-Host "Pip already exists, skipping" -ForegroundColor Green
 }
+
+# Python 3.12's get-pip.py no longer installs these packages automatically.
+& (Join-Path $buildDir "python\python.exe") -m pip install --upgrade setuptools wheel --quiet --no-warn-script-location
+if ($LASTEXITCODE -ne 0) {
+    Write-Host "Failed to install Python build tools" -ForegroundColor Red
+    exit 1
+}
+Write-Host "Python build tools installed" -ForegroundColor Green
 
 # Step 5: Install dependencies from pyproject.toml
 Write-Host "`n[5/9] Installing Python dependencies..." -ForegroundColor Yellow


### PR DESCRIPTION
This pull request updates the `packaging/build.ps1` script to improve compatibility with Python 3.12 by ensuring required build tools are installed. The main changes are:

Python build tool installation:

* The script now installs `setuptools` and `wheel` using pip after bootstrapping, addressing a change in Python 3.12 where `get-pip.py` no longer installs these packages by default. 

* Updated status messages to reflect the installation of both pip and Python build tools.