### PR TITLE
Fix/inno metadata

### DIFF
--- a/beratools/__init__.py
+++ b/beratools/__init__.py
@@ -1,6 +1,6 @@
 __author__ = """Applied Geospatial Research Group"""
 __email__ = 'appliedgrg@gmail.com'
-__version__ = '0.5.2'
+__version__ = '0.5.3'
 __license__ = "GPL-3.0-or-later"
 __copyright__ = "Copyright (c) AppliedGRG"
 __status__ = "Pre-Alpha"

--- a/docs/files/developer/publishing.md
+++ b/docs/files/developer/publishing.md
@@ -80,6 +80,10 @@ The test certificate is self-signed, so `Get-AuthenticodeSignature` may report `
 
 The person who creates the tag does not need to be a SignPath approver. With multiple approvers and one required approval, any listed approver can authorize the request. If the request is denied or times out, the workflow does not publish the installer. A rerun does not overwrite an installer asset that is already attached to the release.
 
+### Installer Identity
+
+Before tagging a release, update `beratools.__version__` to the same `major.minor.patch` value. The validated release tag becomes `APP_VERSION`, which supplies that version to `packaging/beratools.iss` for the installer filename, Installed Apps version, and executable product/file versions. Do not hardcode a separate version in the Inno script. Publisher, company, support, and update metadata remain stable; the Authenticode publisher comes from the signing certificate and therefore appears as **SignPath Foundation**.
+
 ### SignPath Configuration
 
 Open **Projects -> beratools -> Signing policies** in SignPath to review policy settings.

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -10,6 +10,8 @@ recipe.yaml
 - `beratools.iss`: defines the installer layout and Windows version metadata.
 - `main.go`: builds the Windows GUI launcher included in the installer.
 
+Keep `beratools.__version__` and the release tag identical. The release workflow passes the validated tag to `build.ps1` as `APP_VERSION`, and `beratools.iss` uses it for all installer version fields and the output filename. Do not hardcode an independent version in the Inno script.
+
 ## Build locally
 
 Run the following command to build the Windows installer locally:

--- a/packaging/beratools.iss
+++ b/packaging/beratools.iss
@@ -5,9 +5,16 @@
 
 [Setup]
 AppName=BERA Tools
+AppPublisher=Applied Geospatial Research Group
+AppPublisherURL=https://www.appliedgrg.ca/
+AppSupportURL=https://github.com/appliedgrg/beratools/issues
+AppUpdatesURL=https://github.com/appliedgrg/beratools/releases/latest
 WizardImageFile=..\beratools\gui\assets\BERA_WizardImage.png
 AppVersion={#MyAppVersion}
 VersionInfoVersion={#MyAppVersion}
+VersionInfoCompany=Applied Geospatial Research Group
+VersionInfoDescription=BERA Tools Installer
+VersionInfoCopyright=Copyright (c) 2026 Applied Geospatial Research Group
 VersionInfoProductName=BERA Tools
 VersionInfoProductVersion={#MyAppVersion}
 VersionInfoProductTextVersion={#MyAppVersion}


### PR DESCRIPTION
This pull request focuses on improving the release process and installer metadata consistency for the BERA Tools project. The main changes ensure that the application version is managed in a single place, and that installer and executable metadata are accurate and consistent. Documentation has been updated to clarify these processes.

**Release and versioning process improvements:**

* Clarified in `docs/files/developer/publishing.md` and `packaging/README.md` that `beratools.__version__` and the release tag must match, and that the installer version is derived from this value—removing the need to hardcode the version in the Inno Setup script.

**Installer metadata enhancements:**

* Added publisher, company, support, and update URLs, as well as a description and copyright, to the installer metadata in `packaging/beratools.iss` for improved identification and professionalism.